### PR TITLE
Implement rackspace_managed flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 | primary_ebs_volume_size | EBS Volume Size in GB | string | `60` | no |
 | primary_ebs_volume_type | EBS Volume Type. e.g. gp2, io1, st1, sc1 | string | `gp2` | no |
 | private_ip_address | A list of static private IP addresses to be configured on the instance.  This IP should be in the assigned subnet and if the instance is replaced, a new IP would need to be assigned. If used, one private IP needs to be provided per instance. | list | `<list>` | no |
+| rackspace_managed | Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents. | string | `true` | no |
 | resource_name | Name to be used for the provisioned EC2 instance(s) and other resources provisioned in this module | string | - | yes |
 | secondary_ebs_volume_iops | Iops value required for use with io1 EBS volumes. This value should be 3 times the EBS volume size | string | `0` | no |
 | secondary_ebs_volume_size | EBS Volume Size in GB | string | `` | no |
@@ -50,4 +51,3 @@
 | Name | Description |
 |------|-------------|
 | ar_instance_id_list | List of resulting Instance IDs |
-

--- a/examples/unmanaged.tf
+++ b/examples/unmanaged.tf
@@ -1,0 +1,47 @@
+provider "aws" {
+  version = "~> 1.2"
+  region  = "us-west-2"
+}
+
+module "vpc" {
+  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.1"
+  vpc_name = "EC2-AR-BaseNetwork-Test1"
+}
+
+data "aws_region" "current_region" {}
+
+# Lookup the correct AMI based on the region specified
+data "aws_ami" "amazon_centos_7" {
+  most_recent = true
+
+  owners = [
+    "679593333241",
+  ]
+
+  filter {
+    name = "name"
+
+    values = [
+      "CentOS Linux 7 x86_64 HVM EBS*",
+    ]
+  }
+}
+
+module "sns" {
+  source     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//?ref=v0.0.1"
+  topic_name = "my-alarm-notification-topic"
+}
+
+module "unmanaged_ar" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.1"
+
+  ec2_os                   = "centos7"
+  instance_count           = "1"
+  ec2_subnet               = "${element(module.vpc.private_subnets, 0)}"
+  security_group_list      = ["${module.vpc.default_sg}"]
+  image_id                 = "${data.aws_ami.instance.image_id}"
+  instance_type            = "t2.micro"
+  resource_name            = "my_unmanaged_instance"
+  alarm_notification_topic = "${module.sns.topic_arn}"
+  rackspace_managed        = false
+}

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -31,7 +31,7 @@ module "ec2_ar_centos7_with_codedeploy" {
   key_pair                           = "CircleCI"
   instance_type                      = "t2.micro"
   resource_name                      = "ec2_ar_centos7_with_codedeploy"
-  install_codedeploy_agent           = "False"
+  install_codedeploy_agent           = true
   enable_ebs_optimization            = "False"
   tenancy                            = "default"
   backup_tag_value                   = "False"
@@ -352,4 +352,23 @@ EOF
     MyTag2 = "MyValue2"
     MyTag3 = "MyValue3"
   }
+}
+
+module "sns" {
+  source     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//"
+  topic_name = "my-alarm-notification-topic"
+}
+
+module "unmanaged_ar" {
+  source = "../../module"
+
+  ec2_os                   = "centos7"
+  instance_count           = "1"
+  ec2_subnet               = "${element(module.vpc.private_subnets, 0)}"
+  security_group_list      = ["${module.vpc.default_sg}"]
+  image_id                 = "${data.aws_ami.amazon_centos_7.image_id}"
+  instance_type            = "t2.micro"
+  resource_name            = "my_unmanaged_instance"
+  alarm_notification_topic = "${module.sns.topic_arn}"
+  rackspace_managed        = false
 }

--- a/text/managed_ssm_steps.json
+++ b/text/managed_ssm_steps.json
@@ -1,0 +1,30 @@
+    {
+      "action": "aws:runDocument",
+      "inputs": {
+      "documentPath": "arn:aws:ssm:${region}:507897595701:document/Rack-ConfigureAWSTimeSync",
+      "documentType": "SSMDocument"
+      },
+      "name": "SetupTimeSync",
+      "timeoutSeconds": 300
+    },
+    {
+      "action": "aws:runDocument",
+      "inputs": {
+      "documentPath": "arn:aws:ssm:${region}:507897595701:document/Rack-Install_ScaleFT",
+      "documentType": "SSMDocument"
+      },
+      "name": "SetupPassport",
+      "timeoutSeconds": 300
+    },
+    {
+      "action": "aws:runDocument",
+      "inputs": {
+      "documentPath": "arn:aws:ssm:${region}:507897595701:document/Rack-Install_Package",
+      "documentParameters": {
+        "Packages": "sysstat ltrace strace iptraf tcpdump"
+      },
+      "documentType": "SSMDocument"
+      },
+      "name": "DiagnosticTools",
+      "timeoutSeconds": 300
+    },

--- a/text/ssm_bootstrap_template.json
+++ b/text/ssm_bootstrap_template.json
@@ -2,5 +2,44 @@
   "schemaVersion": "2.2",
   "description": "SSM Document for instance configuration.",
   "parameters": {},
-  "mainSteps": [${run_command_list}]
+  "mainSteps": [
+    {
+      "action": "aws:runDocument",
+      "inputs": {
+        "documentPath": "AWS-ConfigureAWSPackage",
+        "documentParameters": {
+          "action": "Install",
+          "name": "AmazonCloudWatchAgent"
+        },
+        "documentType": "SSMDocument"
+      },
+      "name": "InstallCWAgent",
+      "timeoutSeconds": 300
+    },
+    {
+      "action": "aws:runDocument",
+      "inputs": {
+        "documentPath": "AmazonCloudWatch-ManageAgent",
+        "documentParameters": {
+          "action": "configure",
+          "optionalConfigurationSource": "ssm",
+          "optionalConfigurationLocation": "${cw_agent_param}",
+          "optionalRestart": "yes",
+          "name": "AmazonCloudWatchAgent"
+        },
+        "documentType": "SSMDocument"
+      },
+      "name": "ConfigureCWAgent",
+      "timeoutSeconds": 300
+    },${managed_ssm_docs}${codedeploy_doc}${additional_ssm_docs}
+    {
+      "action": "aws:runDocument",
+      "inputs": {
+        "documentPath": "AWS-UpdateSSMAgent",
+        "documentType": "SSMDocument"
+      },
+      "name": "UpdateSSMAgent",
+      "timeoutSeconds": 300
+    }
+  ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -199,6 +199,12 @@ variable "perform_ssm_inventory_tag" {
   default     = "True"
 }
 
+variable "rackspace_managed" {
+  description = "Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents."
+  type        = "string"
+  default     = true
+}
+
 variable "ssm_association_refresh_rate" {
   description = "A cron or rate pattern to define the SSM Association refresh schedule, defaulting to once per day. See https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-cron.html for more details. Schedule can be disabled by providing an empty string."
   type        = "string"


### PR DESCRIPTION
Implements a `rackspace_managed` parameter.  When this parameter is set to false, Rackspace managed SSM documents are removed from the bootstrapping process and all CloudWatch alarms will use the provided SNS topic instead of the various watchman alarm topics.