### PR TITLE
Fix eip allocation issue

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -28,7 +28,7 @@ data "aws_ami" "amazon_centos_7" {
 }
 
 module "ec2_ar" {
-  source                            = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.1"
+  source                            = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.2"
   ec2_os                            = "centos7"
   instance_count                    = "3"
   ec2_subnet                        = "${element(module.vpc.public_subnets, 0)}"
@@ -56,7 +56,7 @@ module "ec2_ar" {
   cloudwatch_log_retention          = "30"
   ssm_association_refresh_rate      = "rate(1 day)"
 
-  addtional_ssm_bootstrap_list = [
+  additional_ssm_bootstrap_list = [
     {
       ssm_add_step = <<EOF
       {
@@ -91,18 +91,18 @@ EOF
     },
   ]
 
-  addtional_ssm_bootstrap_step_count = "1"
-  private_ip_address                 = ["10.0.1.131", "10.0.1.132", "10.0.1.133"]
-  eip_allocation_id_list             = ["${aws_eip.my_eips.*.id}"]
-  eip_allocation_id_count            = "3"
-  alarm_notification_topic           = ""
-  disable_api_termination            = "False"
-  t2_unlimited_mode                  = "standard"
-  creation_policy_timeout            = "20m"
-  cw_cpu_high_operator               = "GreaterThanThreshold"
-  cw_cpu_high_threshold              = "90"
-  cw_cpu_high_evaluations            = "15"
-  cw_cpu_high_period                 = "60"
+  additional_ssm_bootstrap_step_count = "1"
+  private_ip_address                  = ["10.0.1.131", "10.0.1.132", "10.0.1.133"]
+  eip_allocation_id_list              = ["${aws_eip.my_eips.*.id}"]
+  eip_allocation_id_count             = "3"
+  alarm_notification_topic            = ""
+  disable_api_termination             = "False"
+  t2_unlimited_mode                   = "standard"
+  creation_policy_timeout             = "20m"
+  cw_cpu_high_operator                = "GreaterThanThreshold"
+  cw_cpu_high_threshold               = "90"
+  cw_cpu_high_evaluations             = "15"
+  cw_cpu_high_period                  = "60"
 
   additional_tags = {
     MyTag1 = "MyValue1"

--- a/examples/unmanaged.tf
+++ b/examples/unmanaged.tf
@@ -33,13 +33,13 @@ module "sns" {
 }
 
 module "unmanaged_ar" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.2"
 
   ec2_os                   = "centos7"
   instance_count           = "1"
   ec2_subnet               = "${element(module.vpc.private_subnets, 0)}"
   security_group_list      = ["${module.vpc.default_sg}"]
-  image_id                 = "${data.aws_ami.instance.image_id}"
+  image_id                 = "${data.aws_ami.amazon_centos_7.image_id}"
   instance_type            = "t2.micro"
   resource_name            = "my_unmanaged_instance"
   alarm_notification_topic = "${module.sns.topic_arn}"

--- a/main.tf
+++ b/main.tf
@@ -435,6 +435,6 @@ resource "aws_eip_association" "eip_assoc" {
   count = "${var.eip_allocation_id_count}"
 
   # coalescelist and list("novalue") were used here due to element not being able to handle empty lists, even if conditional will not allow portion to execute
-  instance_id   = "${var.primary_ebs_volume_size != "" ? element(coalescelist(aws_instance.mod_ec2_instance_with_secondary_ebs.*.id, list("novalue")), count.index) : element(coalescelist(aws_instance.mod_ec2_instance_no_secondary_ebs.*.id, list("novalue")), count.index)}"
+  instance_id   = "${var.secondary_ebs_volume_size != "" ? element(coalescelist(aws_instance.mod_ec2_instance_with_secondary_ebs.*.id, list("novalue")), count.index) : element(coalescelist(aws_instance.mod_ec2_instance_no_secondary_ebs.*.id, list("novalue")), count.index)}"
   allocation_id = "${element(var.eip_allocation_id_list, count.index)}"
 }

--- a/main.tf
+++ b/main.tf
@@ -183,11 +183,11 @@ data "template_file" "ssm_managed_commands" {
 }
 
 data "template_file" "additional_ssm_docs" {
-  template = "    $${addtional_ssm_cmd_json},"
-  count    = "${var.addtional_ssm_bootstrap_step_count}"
+  template = "    $${additional_ssm_cmd_json},"
+  count    = "${var.additional_ssm_bootstrap_step_count}"
 
   vars {
-    addtional_ssm_cmd_json = "${trimspace(lookup(var.addtional_ssm_bootstrap_list[count.index], "ssm_add_step"))}"
+    additional_ssm_cmd_json = "${trimspace(lookup(var.additional_ssm_bootstrap_list[count.index], "ssm_add_step"))}"
   }
 }
 

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -21,6 +21,14 @@ data "aws_ami" "amazon_centos_7" {
   }
 }
 
+resource "aws_eip" "test_eip_1" {
+  vpc = true
+
+  tags = {
+    Name = "Circle-CI-Test1-1"
+  }
+}
+
 module "ec2_ar_centos7_with_codedeploy" {
   source                             = "../../module"
   ec2_os                             = "centos7"
@@ -40,9 +48,6 @@ module "ec2_ar_centos7_with_codedeploy" {
   primary_ebs_volume_size            = "60"
   primary_ebs_volume_iops            = "0"
   primary_ebs_volume_type            = "gp2"
-  secondary_ebs_volume_size          = "60"
-  secondary_ebs_volume_iops          = "0"
-  secondary_ebs_volume_type          = "gp2"
   encrypt_secondary_ebs_volume       = "False"
   environment                        = "Development"
   instance_role_managed_policy_arns  = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole", "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access"]
@@ -58,6 +63,8 @@ module "ec2_ar_centos7_with_codedeploy" {
   cw_cpu_high_threshold              = "90"
   cw_cpu_high_evaluations            = "15"
   cw_cpu_high_period                 = "60"
+  eip_allocation_id_count            = "1"
+  eip_allocation_id_list             = ["${aws_eip.test_eip_1.id}"]
 
   addtional_ssm_bootstrap_list = [
     {
@@ -101,6 +108,14 @@ EOF
   }
 }
 
+resource "aws_eip" "test_eip_2" {
+  vpc = true
+
+  tags = {
+    Name = "Circle-CI-Test1-2"
+  }
+}
+
 module "ec2_ar_centos7_no_codedeploy" {
   source                             = "../../module"
   ec2_os                             = "centos7"
@@ -138,6 +153,8 @@ module "ec2_ar_centos7_no_codedeploy" {
   cw_cpu_high_threshold              = "90"
   cw_cpu_high_evaluations            = "15"
   cw_cpu_high_period                 = "60"
+  eip_allocation_id_count            = "1"
+  eip_allocation_id_list             = ["${aws_eip.test_eip_2.id}"]
 
   addtional_ssm_bootstrap_list = [
     {

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -30,43 +30,43 @@ resource "aws_eip" "test_eip_1" {
 }
 
 module "ec2_ar_centos7_with_codedeploy" {
-  source                             = "../../module"
-  ec2_os                             = "centos7"
-  instance_count                     = "3"
-  ec2_subnet                         = "${element(module.vpc.public_subnets, 0)}"
-  security_group_list                = ["${module.vpc.default_sg}"]
-  image_id                           = "${data.aws_ami.amazon_centos_7.image_id}"
-  key_pair                           = "CircleCI"
-  instance_type                      = "t2.micro"
-  resource_name                      = "ec2_ar_centos7_with_codedeploy"
-  install_codedeploy_agent           = true
-  enable_ebs_optimization            = "False"
-  tenancy                            = "default"
-  backup_tag_value                   = "False"
-  detailed_monitoring                = "True"
-  ssm_patching_group                 = "Group1Patching"
-  primary_ebs_volume_size            = "60"
-  primary_ebs_volume_iops            = "0"
-  primary_ebs_volume_type            = "gp2"
-  encrypt_secondary_ebs_volume       = "False"
-  environment                        = "Development"
-  instance_role_managed_policy_arns  = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole", "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access"]
-  perform_ssm_inventory_tag          = "True"
-  cloudwatch_log_retention           = "30"
-  ssm_association_refresh_rate       = "rate(1 day)"
-  addtional_ssm_bootstrap_step_count = "2"
-  alarm_notification_topic           = ""
-  disable_api_termination            = "False"
-  t2_unlimited_mode                  = "standard"
-  creation_policy_timeout            = "20m"
-  cw_cpu_high_operator               = "GreaterThanThreshold"
-  cw_cpu_high_threshold              = "90"
-  cw_cpu_high_evaluations            = "15"
-  cw_cpu_high_period                 = "60"
-  eip_allocation_id_count            = "1"
-  eip_allocation_id_list             = ["${aws_eip.test_eip_1.id}"]
+  source                              = "../../module"
+  ec2_os                              = "centos7"
+  instance_count                      = "3"
+  ec2_subnet                          = "${element(module.vpc.public_subnets, 0)}"
+  security_group_list                 = ["${module.vpc.default_sg}"]
+  image_id                            = "${data.aws_ami.amazon_centos_7.image_id}"
+  key_pair                            = "CircleCI"
+  instance_type                       = "t2.micro"
+  resource_name                       = "ec2_ar_centos7_with_codedeploy"
+  install_codedeploy_agent            = true
+  enable_ebs_optimization             = "False"
+  tenancy                             = "default"
+  backup_tag_value                    = "False"
+  detailed_monitoring                 = "True"
+  ssm_patching_group                  = "Group1Patching"
+  primary_ebs_volume_size             = "60"
+  primary_ebs_volume_iops             = "0"
+  primary_ebs_volume_type             = "gp2"
+  encrypt_secondary_ebs_volume        = "False"
+  environment                         = "Development"
+  instance_role_managed_policy_arns   = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole", "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access"]
+  perform_ssm_inventory_tag           = "True"
+  cloudwatch_log_retention            = "30"
+  ssm_association_refresh_rate        = "rate(1 day)"
+  additional_ssm_bootstrap_step_count = "2"
+  alarm_notification_topic            = ""
+  disable_api_termination             = "False"
+  t2_unlimited_mode                   = "standard"
+  creation_policy_timeout             = "20m"
+  cw_cpu_high_operator                = "GreaterThanThreshold"
+  cw_cpu_high_threshold               = "90"
+  cw_cpu_high_evaluations             = "15"
+  cw_cpu_high_period                  = "60"
+  eip_allocation_id_count             = "1"
+  eip_allocation_id_list              = ["${aws_eip.test_eip_1.id}"]
 
-  addtional_ssm_bootstrap_list = [
+  additional_ssm_bootstrap_list = [
     {
       ssm_add_step = <<EOF
       {
@@ -117,46 +117,46 @@ resource "aws_eip" "test_eip_2" {
 }
 
 module "ec2_ar_centos7_no_codedeploy" {
-  source                             = "../../module"
-  ec2_os                             = "centos7"
-  instance_count                     = "3"
-  ec2_subnet                         = "${element(module.vpc.public_subnets, 0)}"
-  security_group_list                = ["${module.vpc.default_sg}"]
-  image_id                           = "${data.aws_ami.amazon_centos_7.image_id}"
-  key_pair                           = "CircleCI"
-  instance_type                      = "t2.micro"
-  resource_name                      = "ec2_ar_centos7_no_codedeploy"
-  install_codedeploy_agent           = false
-  enable_ebs_optimization            = "False"
-  tenancy                            = "default"
-  backup_tag_value                   = "False"
-  detailed_monitoring                = "True"
-  ssm_patching_group                 = "Group1Patching"
-  primary_ebs_volume_size            = "60"
-  primary_ebs_volume_iops            = "0"
-  primary_ebs_volume_type            = "gp2"
-  secondary_ebs_volume_size          = "60"
-  secondary_ebs_volume_iops          = "0"
-  secondary_ebs_volume_type          = "gp2"
-  encrypt_secondary_ebs_volume       = "False"
-  environment                        = "Development"
-  instance_role_managed_policy_arns  = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole", "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access"]
-  perform_ssm_inventory_tag          = "True"
-  cloudwatch_log_retention           = "30"
-  ssm_association_refresh_rate       = "rate(1 day)"
-  addtional_ssm_bootstrap_step_count = "2"
-  alarm_notification_topic           = ""
-  disable_api_termination            = "False"
-  t2_unlimited_mode                  = "standard"
-  creation_policy_timeout            = "20m"
-  cw_cpu_high_operator               = "GreaterThanThreshold"
-  cw_cpu_high_threshold              = "90"
-  cw_cpu_high_evaluations            = "15"
-  cw_cpu_high_period                 = "60"
-  eip_allocation_id_count            = "1"
-  eip_allocation_id_list             = ["${aws_eip.test_eip_2.id}"]
+  source                              = "../../module"
+  ec2_os                              = "centos7"
+  instance_count                      = "3"
+  ec2_subnet                          = "${element(module.vpc.public_subnets, 0)}"
+  security_group_list                 = ["${module.vpc.default_sg}"]
+  image_id                            = "${data.aws_ami.amazon_centos_7.image_id}"
+  key_pair                            = "CircleCI"
+  instance_type                       = "t2.micro"
+  resource_name                       = "ec2_ar_centos7_no_codedeploy"
+  install_codedeploy_agent            = false
+  enable_ebs_optimization             = "False"
+  tenancy                             = "default"
+  backup_tag_value                    = "False"
+  detailed_monitoring                 = "True"
+  ssm_patching_group                  = "Group1Patching"
+  primary_ebs_volume_size             = "60"
+  primary_ebs_volume_iops             = "0"
+  primary_ebs_volume_type             = "gp2"
+  secondary_ebs_volume_size           = "60"
+  secondary_ebs_volume_iops           = "0"
+  secondary_ebs_volume_type           = "gp2"
+  encrypt_secondary_ebs_volume        = "False"
+  environment                         = "Development"
+  instance_role_managed_policy_arns   = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole", "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access"]
+  perform_ssm_inventory_tag           = "True"
+  cloudwatch_log_retention            = "30"
+  ssm_association_refresh_rate        = "rate(1 day)"
+  additional_ssm_bootstrap_step_count = "2"
+  alarm_notification_topic            = ""
+  disable_api_termination             = "False"
+  t2_unlimited_mode                   = "standard"
+  creation_policy_timeout             = "20m"
+  cw_cpu_high_operator                = "GreaterThanThreshold"
+  cw_cpu_high_threshold               = "90"
+  cw_cpu_high_evaluations             = "15"
+  cw_cpu_high_period                  = "60"
+  eip_allocation_id_count             = "1"
+  eip_allocation_id_list              = ["${aws_eip.test_eip_2.id}"]
 
-  addtional_ssm_bootstrap_list = [
+  additional_ssm_bootstrap_list = [
     {
       ssm_add_step = <<EOF
       {
@@ -208,44 +208,44 @@ data "aws_ami" "amazon_windows_2016" {
 }
 
 module "ec2_ar_windows_with_codedeploy" {
-  source                             = "../../module"
-  ec2_os                             = "windows"
-  instance_count                     = "3"
-  ec2_subnet                         = "${element(module.vpc.public_subnets, 0)}"
-  security_group_list                = ["${module.vpc.default_sg}"]
-  image_id                           = "${data.aws_ami.amazon_windows_2016.image_id}"
-  key_pair                           = "CircleCI"
-  instance_type                      = "t2.micro"
-  resource_name                      = "ec2_ar_windows_with_codedeploy"
-  install_codedeploy_agent           = true
-  enable_ebs_optimization            = "False"
-  tenancy                            = "default"
-  backup_tag_value                   = "False"
-  detailed_monitoring                = "True"
-  ssm_patching_group                 = "Group1Patching"
-  primary_ebs_volume_size            = "60"
-  primary_ebs_volume_iops            = "0"
-  primary_ebs_volume_type            = "gp2"
-  secondary_ebs_volume_size          = "60"
-  secondary_ebs_volume_iops          = "0"
-  secondary_ebs_volume_type          = "gp2"
-  encrypt_secondary_ebs_volume       = "False"
-  environment                        = "Development"
-  instance_role_managed_policy_arns  = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole", "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access"]
-  perform_ssm_inventory_tag          = "True"
-  cloudwatch_log_retention           = "30"
-  ssm_association_refresh_rate       = "rate(1 day)"
-  addtional_ssm_bootstrap_step_count = "2"
-  alarm_notification_topic           = ""
-  disable_api_termination            = "False"
-  t2_unlimited_mode                  = "standard"
-  creation_policy_timeout            = "20m"
-  cw_cpu_high_operator               = "GreaterThanThreshold"
-  cw_cpu_high_threshold              = "90"
-  cw_cpu_high_evaluations            = "15"
-  cw_cpu_high_period                 = "60"
+  source                              = "../../module"
+  ec2_os                              = "windows"
+  instance_count                      = "3"
+  ec2_subnet                          = "${element(module.vpc.public_subnets, 0)}"
+  security_group_list                 = ["${module.vpc.default_sg}"]
+  image_id                            = "${data.aws_ami.amazon_windows_2016.image_id}"
+  key_pair                            = "CircleCI"
+  instance_type                       = "t2.micro"
+  resource_name                       = "ec2_ar_windows_with_codedeploy"
+  install_codedeploy_agent            = true
+  enable_ebs_optimization             = "False"
+  tenancy                             = "default"
+  backup_tag_value                    = "False"
+  detailed_monitoring                 = "True"
+  ssm_patching_group                  = "Group1Patching"
+  primary_ebs_volume_size             = "60"
+  primary_ebs_volume_iops             = "0"
+  primary_ebs_volume_type             = "gp2"
+  secondary_ebs_volume_size           = "60"
+  secondary_ebs_volume_iops           = "0"
+  secondary_ebs_volume_type           = "gp2"
+  encrypt_secondary_ebs_volume        = "False"
+  environment                         = "Development"
+  instance_role_managed_policy_arns   = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole", "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access"]
+  perform_ssm_inventory_tag           = "True"
+  cloudwatch_log_retention            = "30"
+  ssm_association_refresh_rate        = "rate(1 day)"
+  additional_ssm_bootstrap_step_count = "2"
+  alarm_notification_topic            = ""
+  disable_api_termination             = "False"
+  t2_unlimited_mode                   = "standard"
+  creation_policy_timeout             = "20m"
+  cw_cpu_high_operator                = "GreaterThanThreshold"
+  cw_cpu_high_threshold               = "90"
+  cw_cpu_high_evaluations             = "15"
+  cw_cpu_high_period                  = "60"
 
-  addtional_ssm_bootstrap_list = [
+  additional_ssm_bootstrap_list = [
     {
       ssm_add_step = <<EOF
       {
@@ -319,20 +319,20 @@ module "ec2_ar_windows_no_codedeploy" {
     "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access",
   ]
 
-  perform_ssm_inventory_tag          = "True"
-  cloudwatch_log_retention           = "30"
-  ssm_association_refresh_rate       = "rate(1 day)"
-  addtional_ssm_bootstrap_step_count = "2"
-  alarm_notification_topic           = ""
-  disable_api_termination            = "False"
-  t2_unlimited_mode                  = "standard"
-  creation_policy_timeout            = "20m"
-  cw_cpu_high_operator               = "GreaterThanThreshold"
-  cw_cpu_high_threshold              = "90"
-  cw_cpu_high_evaluations            = "15"
-  cw_cpu_high_period                 = "60"
+  perform_ssm_inventory_tag           = "True"
+  cloudwatch_log_retention            = "30"
+  ssm_association_refresh_rate        = "rate(1 day)"
+  additional_ssm_bootstrap_step_count = "2"
+  alarm_notification_topic            = ""
+  disable_api_termination             = "False"
+  t2_unlimited_mode                   = "standard"
+  creation_policy_timeout             = "20m"
+  cw_cpu_high_operator                = "GreaterThanThreshold"
+  cw_cpu_high_threshold               = "90"
+  cw_cpu_high_evaluations             = "15"
+  cw_cpu_high_period                  = "60"
 
-  addtional_ssm_bootstrap_list = [
+  additional_ssm_bootstrap_list = [
     {
       ssm_add_step = <<EOF
       {

--- a/variables.tf
+++ b/variables.tf
@@ -181,14 +181,14 @@ variable "environment" {
 # SSM and Associations
 #
 
-variable "addtional_ssm_bootstrap_list" {
+variable "additional_ssm_bootstrap_list" {
   description = "A list of maps consisting of main step actions, to be appended to SSM associations. Please see usage.tf.example in this repo for examples."
   type        = "list"
   default     = []
 }
 
-variable "addtional_ssm_bootstrap_step_count" {
-  description = "Count of steps added for input 'addtional_ssm_bootstrap_list'. This is required since 'addtional_ssm_bootstrap_list' is a list of maps"
+variable "additional_ssm_bootstrap_step_count" {
+  description = "Count of steps added for input 'additional_ssm_bootstrap_list'. This is required since 'additional_ssm_bootstrap_list' is a list of maps"
   type        = "string"
   default     = "0"
 }


### PR DESCRIPTION
Reference: https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/85 and https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/86

- Bug was caused by EIP resource association being based on the wrong input variable. This has been fixed.
- Also realized that case for EC2 instances without secondary EBS volumes were not being tested. Add test for that case. 
- Fix typo with SSM bootstrapping variables.