### PR TITLE
additional_userdata_update

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,10 @@ EOF
 data "template_file" "user_data" {
   template = "${file("${path.module}/text/${lookup(local.user_data_map, var.ec2_os)}")}"
 
-  vars {}
+  vars {
+    initial_commands = "${var.initial_userdata_commands != "" ? "${var.initial_userdata_commands}" : "" }"
+    final_commands   = "${var.final_userdata_commands != "" ? "${var.final_userdata_commands}" : "" }"
+  }
 }
 
 data "aws_region" "current_region" {}

--- a/text/amazon_linux_userdata.sh
+++ b/text/amazon_linux_userdata.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+${initial_commands}
+
 # Ensure SSM installed on Amazon Linux
 # in cases where it is not available / removed
 ssm_running=$( ps -ef | grep ['a']mazon-ssm-agent | wc -l )
@@ -25,3 +27,5 @@ else
         fi
     fi
 fi
+
+${final_commands}

--- a/text/rhel_centos_6_userdata.sh
+++ b/text/rhel_centos_6_userdata.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -xe
+
+${initial_commands}
+
 exec 1> >(logger -s -t $(basename $0)) 2>&1
 
 mkdir -p /opt/aws/bin
@@ -29,3 +32,5 @@ else
         fi
     fi
 fi
+
+${final_commands}

--- a/text/rhel_centos_7_userdata.sh
+++ b/text/rhel_centos_7_userdata.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -xe
+
+${initial_commands}
+
 exec 1> >(logger -s -t $(basename $0)) 2>&1
 
 mkdir -p /opt/aws/bin
@@ -29,3 +32,5 @@ else
         fi
     fi
 fi
+
+${final_commands}

--- a/text/ubuntu_userdata.sh
+++ b/text/ubuntu_userdata.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -xe
-exec 1> >(logger -s -t $(basename $0)) 2>&1
 
+${initial_commands}
+
+exec 1> >(logger -s -t $(basename $0)) 2>&1
 
 export LC_ALL=C.UTF-8
 
@@ -35,3 +37,5 @@ else
         fi
     fi
 fi
+
+${final_commands}

--- a/text/windows_userdata.ps1
+++ b/text/windows_userdata.ps1
@@ -1,3 +1,7 @@
 <powershell>
 
+${initial_commands}
+
+${final_commands}
+
 </powershell>

--- a/variables.tf
+++ b/variables.tf
@@ -272,3 +272,15 @@ variable "instance_role_managed_policy_arn_count" {
   type        = "string"
   default     = "0"
 }
+
+variable "initial_userdata_commands" {
+  description = "Commands to be given at the start of userdata for an instance. This should generally not include bootstrapping or ssm install."
+  type        = "string"
+  default     = ""
+}
+
+variable "final_userdata_commands" {
+  description = "Commands to be given at the end of userdata for an instance. This should generally not include bootstrapping or ssm install."
+  type        = "string"
+  default     = ""
+}


### PR DESCRIPTION
similar to https://github.com/rackspace-infrastructure-automation/aws-terraform-ec2_asg/pull/8  to keep them alike
adds the ability to do initial and final userdata scripting via a string parameter (single line or multi line). ECS and EKS will be able to add this via an output.