### PR TITLE
Support `instance_count = 0`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -229,6 +229,7 @@ resource "aws_ssm_parameter" "cwagentparam" {
 }
 
 resource "aws_ssm_association" "ssm_bootstrap_assoc" {
+  count               = "${var.instance_count == 0 ? 0 : 1}"
   name                = "${aws_ssm_document.ssm_bootstrap_doc.name}"
   schedule_expression = "${var.ssm_association_refresh_rate}"
 

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -397,3 +397,17 @@ module "unmanaged_ar" {
   alarm_notification_topic = "${module.sns.topic_arn}"
   rackspace_managed        = false
 }
+
+module "zero_count_ar" {
+  source = "../../module"
+
+  ec2_os                   = "centos7"
+  instance_count           = "0"
+  subnets                  = []
+  security_group_list      = ["${module.vpc.default_sg}"]
+  image_id                 = "${data.aws_ami.amazon_centos_7.image_id}"
+  instance_type            = "t2.micro"
+  resource_name            = "my_nonexistent_instance"
+  alarm_notification_topic = "${module.sns.topic_arn}"
+  rackspace_managed        = false
+}


### PR DESCRIPTION
Fix error when creating 0 instances

Why would anyone want to create zero instances?

Suppose there are templates being re-used for multiple environments, and in a development or test environment, multiple major application roles/functions (let's call them "foo" and "bar") are handled by a single instance to save on costs. In production, however, each major application role lives on its own instance(s) for better resiliency.

Since Terraform doesn't support conditional invocation of modules, specifying an `instance_count` of `0` for "foo" and "bar" in dev/test and an `instance_count` of `1` for "foobar", while specifying an `instance_count` of `1` for "foo" and "bar", respectively, and `0` for "foobar" in Production, would permit reuse across environments and avoid a lot of copy-paste that may drift.

**Note:** The SSM document association portion was the only part of this template that was currently producing errors, so it's the only one I addressed. This will technically still create all of the other base resources like roles, iam policies, etc. We can tie those to `instance_count` as well, if desired.