### PR TITLE
Add IP outputs to module

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,10 +5,14 @@ output "ar_instance_id_list" {
 
 output "ar_instance_ip_list" {
   description = "List of resulting Instance IP addresses"
-  value       = ["${split(",",var.secondary_ebs_volume_size != "" ? join(",",coalescelist(aws_instance.mod_ec2_instance_with_secondary_ebs.*.private_ip, list("novalue"))) : join(",",coalescelist(aws_instance.mod_ec2_instance_no_secondary_ebs.*.private_ip, list("novalue"))))}"]
+
+  value = [
+    "${aws_instance.mod_ec2_instance_with_secondary_ebs.*.private_ip}",
+    "${aws_instance.mod_ec2_instance_no_secondary_ebs.*.private_ip}",
+  ]
 }
 
 output "ar_instance_id_ip_zipmap" {
   description = "Map of resulting Instance IDs to Instance IP addresses"
-  value       = "${zipmap(output.ar_instance_id_list, output.ar_instance_ip_list)}"
+  value       = "${zipmap(aws_instance.mod_ec2_instance_with_secondary_ebs.*.id, aws_instance.mod_ec2_instance_no_secondary_ebs.*.id)}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,13 @@ output "ar_instance_id_list" {
   description = "List of resulting Instance IDs"
   value       = ["${split(",",var.secondary_ebs_volume_size != "" ? join(",",coalescelist(aws_instance.mod_ec2_instance_with_secondary_ebs.*.id, list("novalue"))) : join(",",coalescelist(aws_instance.mod_ec2_instance_no_secondary_ebs.*.id, list("novalue"))))}"]
 }
+
+output "ar_instance_ip_list" {
+  description = "List of resulting Instance IP addresses"
+  value       = ["${split(",",var.secondary_ebs_volume_size != "" ? join(",",coalescelist(aws_instance.mod_ec2_instance_with_secondary_ebs.*.private_ip, list("novalue"))) : join(",",coalescelist(aws_instance.mod_ec2_instance_no_secondary_ebs.*.private_ip, list("novalue"))))}"]
+}
+
+output "ar_instance_id_ip_zipmap" {
+  description = "Map of resulting Instance IDs to Instance IP addresses"
+  value       = "${zipmap(output.ar_instance_id_list, output.ar_instance_ip_list)}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,10 @@
 output "ar_instance_id_list" {
   description = "List of resulting Instance IDs"
-  value       = ["${split(",",var.secondary_ebs_volume_size != "" ? join(",",coalescelist(aws_instance.mod_ec2_instance_with_secondary_ebs.*.id, list("novalue"))) : join(",",coalescelist(aws_instance.mod_ec2_instance_no_secondary_ebs.*.id, list("novalue"))))}"]
+
+  value = [
+    "${aws_instance.mod_ec2_instance_with_secondary_ebs.*.id}",
+    "${aws_instance.mod_ec2_instance_no_secondary_ebs.*.id}",
+  ]
 }
 
 output "ar_instance_ip_list" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,22 +1,16 @@
 output "ar_instance_id_list" {
   description = "List of resulting Instance IDs"
 
-  value = [
-    "${aws_instance.mod_ec2_instance_with_secondary_ebs.*.id}",
-    "${aws_instance.mod_ec2_instance_no_secondary_ebs.*.id}",
-  ]
+  value = "${concat(aws_instance.mod_ec2_instance_with_secondary_ebs.*.id, aws_instance.mod_ec2_instance_no_secondary_ebs.*.id)}"
 }
 
 output "ar_instance_ip_list" {
   description = "List of resulting Instance IP addresses"
 
-  value = [
-    "${aws_instance.mod_ec2_instance_with_secondary_ebs.*.private_ip}",
-    "${aws_instance.mod_ec2_instance_no_secondary_ebs.*.private_ip}",
-  ]
+  value = "${concat(aws_instance.mod_ec2_instance_with_secondary_ebs.*.private_ip, aws_instance.mod_ec2_instance_no_secondary_ebs.*.private_ip)}"
 }
 
 output "ar_instance_id_ip_zipmap" {
   description = "Map of resulting Instance IDs to Instance IP addresses"
-  value       = "${zipmap(aws_instance.mod_ec2_instance_with_secondary_ebs.*.id, aws_instance.mod_ec2_instance_no_secondary_ebs.*.id)}"
+  value       = "${zipmap(concat(aws_instance.mod_ec2_instance_with_secondary_ebs.*.id, aws_instance.mod_ec2_instance_no_secondary_ebs.*.id), concat(aws_instance.mod_ec2_instance_with_secondary_ebs.*.private_ip, aws_instance.mod_ec2_instance_no_secondary_ebs.*.private_ip))}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,8 +9,3 @@ output "ar_instance_ip_list" {
 
   value = "${concat(aws_instance.mod_ec2_instance_with_secondary_ebs.*.private_ip, aws_instance.mod_ec2_instance_no_secondary_ebs.*.private_ip)}"
 }
-
-output "ar_instance_id_ip_zipmap" {
-  description = "Map of resulting Instance IDs to Instance IP addresses"
-  value       = "${zipmap(concat(aws_instance.mod_ec2_instance_with_secondary_ebs.*.id, aws_instance.mod_ec2_instance_no_secondary_ebs.*.id), concat(aws_instance.mod_ec2_instance_with_secondary_ebs.*.private_ip, aws_instance.mod_ec2_instance_no_secondary_ebs.*.private_ip))}"
-}


### PR DESCRIPTION
No IP outputs for the AR module so you have to create a data object straight after to be able to create Route53 internal records, which is a typical build requirement to create internal records for all resources that can have them. This should be considered a requirement for enhancing parity between CF and Terraform.