### PR TITLE
Add default AMI mappings and query to module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ module "ar" {
 
 Full working references are available at [examples](examples)
 
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -36,14 +37,14 @@ Full working references are available at [examples](examples)
 | detailed_monitoring | Enable Detailed Monitoring? true or false | string | `true` | no |
 | disable_api_termination | Specifies that an instance should not be able to be deleted via the API. true or false. This option must be toggled to false to allow Terraform to destroy the resource. | string | `false` | no |
 | ebs_volume_tags | (Optional) A mapping of tags to assign to the devices created by the instance at launch time. | map | `<map>` | no |
-| ec2_os | Intended Operating System/Distribution of Instance. Valid inputs are ('amazon', 'rhel6', 'rhel7', 'centos6', 'centos7', 'ubuntu14', 'ubuntu16', 'windows') | string | - | yes |
+| ec2_os | Intended Operating System/Distribution of Instance. Valid inputs are ('amazon', 'rhel6', 'rhel7', 'centos6', 'centos7', 'ubuntu14', 'ubuntu16', 'windows2008', 'windows2012R2', 'windows2016') | string | - | yes |
 | eip_allocation_id_count | A count of supplied eip allocation IDs in variable eip_allocation_id_list | string | `0` | no |
 | eip_allocation_id_list | A list of Allocation IDs of the EIPs you want to associate with the instance(s). This is one per instance. e.g. if you specify 2 for instance_count then you must supply two allocation ids  here. | list | `<list>` | no |
 | enable_ebs_optimization | Use EBS Optimized? true or false | string | `false` | no |
 | encrypt_secondary_ebs_volume | Encrypt EBS Volume? true or false | string | `false` | no |
 | environment | Application environment for which this network is being created. Preferred value are Development, Integration, PreProduction, Production, QA, Staging, or Test | string | `Development` | no |
 | final_userdata_commands | Commands to be given at the end of userdata for an instance. This should generally not include bootstrapping or ssm install. | string | `` | no |
-| image_id | The AMI ID to be used to build the EC2 Instance. | string | - | yes |
+| image_id | The AMI ID to be used to build the EC2 Instance. If not provided, an AMI ID will be queried with an OS specified in variable ec2_os. | string | `` | no |
 | initial_userdata_commands | Commands to be given at the start of userdata for an instance. This should generally not include bootstrapping or ssm install. | string | `` | no |
 | install_codedeploy_agent | Install codedeploy agent on instance(s)? true or false | string | `false` | no |
 | instance_count | Number of identical instances to deploy | string | `1` | no |
@@ -72,5 +73,7 @@ Full working references are available at [examples](examples)
 
 | Name | Description |
 |------|-------------|
+| ar_image_id | Image ID used for EC2 provisioning |
 | ar_instance_id_list | List of resulting Instance IDs |
 | ar_instance_ip_list | List of resulting Instance IP addresses |
+

--- a/main.tf
+++ b/main.tf
@@ -30,28 +30,33 @@ resource "random_string" "r_string" {
 
 locals {
   user_data_map = {
-    amazon   = "amazon_linux_userdata.sh"
-    amazon2  = "amazon_linux_userdata.sh"
-    rhel6    = "rhel_centos_6_userdata.sh"
-    rhel7    = "rhel_centos_7_userdata.sh"
-    centos6  = "rhel_centos_6_userdata.sh"
-    centos7  = "rhel_centos_7_userdata.sh"
-    ubuntu14 = "ubuntu_userdata.sh"
-    ubuntu16 = "ubuntu_userdata.sh"
-    ubuntu18 = "ubuntu_userdata.sh"
-    windows  = "windows_userdata.ps1"
+    amazon        = "amazon_linux_userdata.sh"
+    amazon2       = "amazon_linux_userdata.sh"
+    rhel6         = "rhel_centos_6_userdata.sh"
+    rhel7         = "rhel_centos_7_userdata.sh"
+    centos6       = "rhel_centos_6_userdata.sh"
+    centos7       = "rhel_centos_7_userdata.sh"
+    ubuntu14      = "ubuntu_userdata.sh"
+    ubuntu16      = "ubuntu_userdata.sh"
+    ubuntu18      = "ubuntu_userdata.sh"
+    windows2008   = "windows_userdata.ps1"
+    windows2012R2 = "windows_userdata.ps1"
+    windows2016   = "windows_userdata.ps1"
   }
 
   ebs_device_map = {
-    rhel6    = "/dev/sdf"
-    rhel7    = "/dev/sdf"
-    centos6  = "/dev/sdf"
-    centos7  = "/dev/sdf"
-    windows  = "xvdf"
-    ubuntu14 = "/dev/sdf"
-    ubuntu16 = "/dev/sdf"
-    ubuntu18 = "/dev/sdf"
-    amazon   = "/dev/sdf"
+    rhel6         = "/dev/sdf"
+    rhel7         = "/dev/sdf"
+    centos6       = "/dev/sdf"
+    centos7       = "/dev/sdf"
+    windows2008   = "xvdf"
+    windows2012R2 = "xvdf"
+    windows2016   = "xvdf"
+    ubuntu14      = "/dev/sdf"
+    ubuntu16      = "/dev/sdf"
+    ubuntu18      = "/dev/sdf"
+    amazon        = "/dev/sdf"
+    amazon2       = "/dev/sdf"
   }
 
   cwagent_config = "${var.ec2_os != "windows" ? "linux_cw_agent_param.txt" : "windows_cw_agent_param.txt"}"
@@ -93,6 +98,210 @@ EOF
     managed   = "${local.alarm_emergency_ticket}"
     unmanaged = []
   }
+
+  ami_owner_mapping = {
+    amazon        = "137112412989"
+    amazon2       = "137112412989"
+    centos6       = "679593333241"
+    centos7       = "679593333241"
+    rhel6         = "309956199498"
+    rhel7         = "309956199498"
+    ubuntu14      = "099720109477"
+    ubuntu16      = "099720109477"
+    ubuntu18      = "099720109477"
+    windows2008   = "801119661308"
+    windows2012R2 = "801119661308"
+    windows2016   = "801119661308"
+  }
+
+  ami_filter_mapping = {
+    amazon = [
+      {
+        name   = "name"
+        values = ["amzn-ami-hvm-2018.03.0.*gp2"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    amazon2 = [
+      {
+        name   = "name"
+        values = ["amzn2-ami-hvm-2.0.*-ebs"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    centos6 = [
+      {
+        name   = "name"
+        values = ["CentOS Linux 6 x86_64 HVM EBS*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    centos7 = [
+      {
+        name   = "name"
+        values = ["CentOS Linux 7 x86_64 HVM EBS*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    rhel6 = [
+      {
+        name   = "name"
+        values = ["RHEL-6.*_HVM_GA-*x86_64*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    rhel7 = [
+      {
+        name   = "name"
+        values = ["RHEL-7.*_HVM_GA-*x86_64*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    ubuntu14 = [
+      {
+        name   = "name"
+        values = ["*ubuntu-trusty-14.04-amd64-server*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    ubuntu16 = [
+      {
+        name   = "name"
+        values = ["*ubuntu-xenial-16.04-amd64-server*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    ubuntu18 = [
+      {
+        name   = "name"
+        values = ["*ubuntu-bionic-18.04-amd64-server*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    windows2008 = [
+      {
+        name   = "name"
+        values = ["Windows_Server-2008-R2_SP1-English-64Bit-Base*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    windows2012R2 = [
+      {
+        name   = "name"
+        values = ["Windows_Server-2012-R2_RTM-English-64Bit-Base*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+
+    windows2016 = [
+      {
+        name   = "name"
+        values = ["Windows_Server-2016-English-Full-Base*"]
+      },
+      {
+        name   = "root-device-type"
+        values = ["ebs"]
+      },
+      {
+        name   = "virtualization-type"
+        values = ["hvm"]
+      },
+    ]
+  }
+}
+
+# Lookup the correct AMI based on the region specified
+data "aws_ami" "ar_ami" {
+  most_recent = true
+  owners      = ["${local.ami_owner_mapping[var.ec2_os]}"]
+  filter      = ["${local.ami_filter_mapping[var.ec2_os]}"]
 }
 
 data "template_file" "user_data" {
@@ -385,7 +594,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_alarm_high" {
 #
 
 resource "aws_instance" "mod_ec2_instance_no_secondary_ebs" {
-  ami                    = "${var.image_id}"
+  ami                    = "${var.image_id != "" ? var.image_id : data.aws_ami.ar_ami.image_id}"
   count                  = "${var.secondary_ebs_volume_size != "" ? 0 : var.instance_count}"
   subnet_id              = "${element(var.subnets, count.index)}"
   vpc_security_group_ids = ["${var.security_group_list}"]
@@ -425,7 +634,7 @@ resource "aws_instance" "mod_ec2_instance_no_secondary_ebs" {
 }
 
 resource "aws_instance" "mod_ec2_instance_with_secondary_ebs" {
-  ami                    = "${var.image_id}"
+  ami                    = "${var.image_id != "" ? var.image_id : data.aws_ami.ar_ami.image_id}"
   count                  = "${var.secondary_ebs_volume_size != "" ? var.instance_count : 0}"
   subnet_id              = "${element(var.subnets, count.index)}"
   vpc_security_group_ids = ["${var.security_group_list}"]

--- a/main.tf
+++ b/main.tf
@@ -86,8 +86,12 @@ EOF
 
   codedeploy_install     = "${var.install_codedeploy_agent && var.rackspace_managed ? "enabled" : "disabled"}"
   alarm_sns_notification = "${compact(list(var.alarm_notification_topic))}"
-  alarm_emergency_ticket = ["arn:aws:sns:${data.aws_region.current_region.name}:${data.aws_caller_identity.current_account.account_id}:rackspace-support-emergency"]
-  recovery_action        = "${var.rackspace_managed ? "managed" : "unmanaged"}"
+
+  alarm_emergency_ticket = [
+    "arn:aws:sns:${data.aws_region.current_region.name}:${data.aws_caller_identity.current_account.account_id}:rackspace-support-emergency",
+  ]
+
+  recovery_action = "${var.rackspace_managed ? "managed" : "unmanaged"}"
 
   recovery_alarm_action = {
     managed   = "${local.alarm_emergency_ticket}"
@@ -114,186 +118,19 @@ EOF
     windows2016   = "801119661308"
   }
 
-  ami_filter_mapping = {
-    amazon = [
-      {
-        name   = "name"
-        values = ["amzn-ami-hvm-2018.03.0.*gp2"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    amazon2 = [
-      {
-        name   = "name"
-        values = ["amzn2-ami-hvm-2.0.*-ebs"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    centos6 = [
-      {
-        name   = "name"
-        values = ["CentOS Linux 6 x86_64 HVM EBS*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    centos7 = [
-      {
-        name   = "name"
-        values = ["CentOS Linux 7 x86_64 HVM EBS*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    rhel6 = [
-      {
-        name   = "name"
-        values = ["RHEL-6.*_HVM_GA-*x86_64*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    rhel7 = [
-      {
-        name   = "name"
-        values = ["RHEL-7.*_HVM_GA-*x86_64*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    ubuntu14 = [
-      {
-        name   = "name"
-        values = ["*ubuntu-trusty-14.04-amd64-server*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    ubuntu16 = [
-      {
-        name   = "name"
-        values = ["*ubuntu-xenial-16.04-amd64-server*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    ubuntu18 = [
-      {
-        name   = "name"
-        values = ["*ubuntu-bionic-18.04-amd64-server*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    windows2008 = [
-      {
-        name   = "name"
-        values = ["Windows_Server-2008-R2_SP1-English-64Bit-Base*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    windows2012R2 = [
-      {
-        name   = "name"
-        values = ["Windows_Server-2012-R2_RTM-English-64Bit-Base*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
-
-    windows2016 = [
-      {
-        name   = "name"
-        values = ["Windows_Server-2016-English-Full-Base*"]
-      },
-      {
-        name   = "root-device-type"
-        values = ["ebs"]
-      },
-      {
-        name   = "virtualization-type"
-        values = ["hvm"]
-      },
-    ]
+  ami_name_mapping = {
+    amazon        = "amzn-ami-hvm-2018.03.0.*gp2"
+    amazon2       = "amzn2-ami-hvm-2.0.*-ebs"
+    centos6       = "CentOS Linux 6 x86_64 HVM EBS*"
+    centos7       = "CentOS Linux 7 x86_64 HVM EBS*"
+    rhel6         = "RHEL-6.*_HVM_GA-*x86_64*"
+    rhel7         = "RHEL-7.*_HVM_GA-*x86_64*"
+    ubuntu14      = "*ubuntu-trusty-14.04-amd64-server*"
+    ubuntu16      = "*ubuntu-xenial-16.04-amd64-server*"
+    ubuntu18      = "*ubuntu-bionic-18.04-amd64-server*"
+    windows2008   = "Windows_Server-2008-R2_SP1-English-64Bit-Base*"
+    windows2012R2 = "Windows_Server-2012-R2_RTM-English-64Bit-Base*"
+    windows2016   = "Windows_Server-2016-English-Full-Base*"
   }
 }
 
@@ -301,7 +138,21 @@ EOF
 data "aws_ami" "ar_ami" {
   most_recent = true
   owners      = ["${local.ami_owner_mapping[var.ec2_os]}"]
-  filter      = ["${local.ami_filter_mapping[var.ec2_os]}"]
+
+  filter {
+    name   = "name"
+    values = ["${local.ami_name_mapping[var.ec2_os]}"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 data "template_file" "user_data" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,8 @@ output "ar_instance_ip_list" {
 
   value = "${concat(aws_instance.mod_ec2_instance_with_secondary_ebs.*.private_ip, aws_instance.mod_ec2_instance_no_secondary_ebs.*.private_ip)}"
 }
+
+output "ar_image_id" {
+  description = "Image ID used for EC2 provisioning"
+  value       = "${var.image_id != "" ? var.image_id : data.aws_ami.ar_ami.image_id}"
+}

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -43,7 +43,6 @@ module "ec2_ar_centos7_with_codedeploy" {
   instance_count                      = "3"
   subnets                             = "${module.vpc.public_subnets}"
   security_group_list                 = ["${module.vpc.default_sg}"]
-  image_id                            = "${data.aws_ami.amazon_centos_7.image_id}"
   key_pair                            = "CircleCI"
   instance_type                       = "t2.micro"
   resource_name                       = "ar_centos7_codedeploy-${random_string.res_name.result}"
@@ -224,7 +223,7 @@ data "aws_ami" "amazon_windows_2016" {
 
 module "ec2_ar_windows_with_codedeploy" {
   source                              = "../../module"
-  ec2_os                              = "windows"
+  ec2_os                              = "windows2016"
   instance_count                      = "3"
   subnets                             = "${module.vpc.public_subnets}"
   security_group_list                 = ["${module.vpc.default_sg}"]
@@ -301,7 +300,7 @@ EOF
 
 module "ec2_ar_windows_no_codedeploy" {
   source         = "../../module"
-  ec2_os         = "windows"
+  ec2_os         = "windows2016"
   instance_count = "3"
   subnets        = "${module.vpc.public_subnets}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,13 +21,14 @@ variable "disable_api_termination" {
 }
 
 variable "ec2_os" {
-  description = "Intended Operating System/Distribution of Instance. Valid inputs are ('amazon', 'rhel6', 'rhel7', 'centos6', 'centos7', 'ubuntu14', 'ubuntu16', 'windows')"
+  description = "Intended Operating System/Distribution of Instance. Valid inputs are ('amazon', 'rhel6', 'rhel7', 'centos6', 'centos7', 'ubuntu14', 'ubuntu16', 'windows2008', 'windows2012R2', 'windows2016')"
   type        = "string"
 }
 
 variable "image_id" {
-  description = "The AMI ID to be used to build the EC2 Instance."
+  description = "The AMI ID to be used to build the EC2 Instance. If not provided, an AMI ID will be queried with an OS specified in variable ec2_os."
   type        = "string"
+  default     = ""
 }
 
 variable "install_codedeploy_agent" {


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/122
##### Summary of change(s):
- Make `image_id` an optional variable
- If `image_id` is not provided, a suitable AMI will be queried using a data resource based on input provided in variable `ec2_os`
- Update README
- Add output for Image ID

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
- Yes, if Image ID is not manually provided to the module.
- Will cause destruction in tests due to change in tests.
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
N/A

##### If input variables or output variables have changed or has been added, have you updated the README?
YES
##### Do examples need to be updated based on changes?

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.