### PR TITLE
Make use of default Rackspace and SSM policies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Full working references are available at [examples](examples)
 | install\_codedeploy\_agent | Install codedeploy agent on instance(s)? true or false | string | `"false"` | no |
 | install\_nfs | Install NFS service on instance(s)? true or false | string | `"false"` | no |
 | instance\_count | Number of identical instances to deploy | string | `"1"` | no |
+| instance\_profile\_override | Optionally provide an instance profile. Any override profile should contain the permissions required for Rackspace support tooling to continue to function if required. | string | `"false"` | no |
+| instance\_profile\_override\_name | Provide an instance profile name. Any override profile should contain the permissions required for Rackspace support tooling to continue to function if required. To use this set `instance_profile_override` to `true`. | string | `""` | no |
 | instance\_role\_managed\_policy\_arn\_count | The number of policy ARNs provided/set in variable 'instance_role_managed_policy_arns' | string | `"0"` | no |
 | instance\_role\_managed\_policy\_arns | List of IAM policy ARNs for the InstanceRole IAM role. IAM ARNs can be found within the Policies section of the AWS IAM console. e.g. ['arn:aws:iam::aws:policy/AmazonEC2FullAccess', 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM', 'arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole'] | list | `<list>` | no |
 | instance\_type | EC2 Instance Type e.g. 't2.micro' | string | `"t2.micro"` | no |

--- a/main.tf
+++ b/main.tf
@@ -259,43 +259,48 @@ data "aws_iam_policy_document" "mod_ec2_instance_role_policies" {
 }
 
 resource "aws_iam_policy" "create_instance_role_policy" {
+  count       = "${var.instance_profile_override ? 0 : 1}"
   name        = "InstanceRolePolicy-${var.resource_name}"
   description = "Rackspace Instance Role Policies for EC2"
   policy      = "${data.aws_iam_policy_document.mod_ec2_instance_role_policies.json}"
 }
 
 resource "aws_iam_role" "mod_ec2_instance_role" {
+  count              = "${var.instance_profile_override ? 0 : 1}"
   name               = "InstanceRole-${var.resource_name}"
   path               = "/"
   assume_role_policy = "${data.aws_iam_policy_document.mod_ec2_assume_role_policy_doc.json}"
 }
 
 resource "aws_iam_role_policy_attachment" "attach_ssm_policy" {
+  count      = "${var.instance_profile_override ? 0 : 1}"
   role       = "${aws_iam_role.mod_ec2_instance_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
 }
 
 resource "aws_iam_role_policy_attachment" "attach_codedeploy_policy" {
-  count      = "${var.install_codedeploy_agent ? 1 : 0}"
+  count      = "${var.install_codedeploy_agent && var.instance_profile_override != true ? 1 : 0}"
   role       = "${aws_iam_role.mod_ec2_instance_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforAWSCodeDeploy"
 }
 
 resource "aws_iam_role_policy_attachment" "attach_instance_role_policy" {
+  count      = "${var.instance_profile_override ? 0 : 1}"
   role       = "${aws_iam_role.mod_ec2_instance_role.name}"
   policy_arn = "${aws_iam_policy.create_instance_role_policy.arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "attach_additonal_policies" {
-  count      = "${var.instance_role_managed_policy_arn_count}"
+  count      = "${var.instance_profile_override ? 0 : var.instance_role_managed_policy_arn_count}"
   role       = "${aws_iam_role.mod_ec2_instance_role.name}"
   policy_arn = "${element(var.instance_role_managed_policy_arns, count.index)}"
 }
 
 resource "aws_iam_instance_profile" "instance_role_instance_profile" {
-  name = "InstanceRoleInstanceProfile-${var.resource_name}"
-  role = "${aws_iam_role.mod_ec2_instance_role.name}"
-  path = "/"
+  count = "${var.instance_profile_override ? 0 : 1}"
+  name  = "InstanceRoleInstanceProfile-${var.resource_name}"
+  role  = "${aws_iam_role.mod_ec2_instance_role.name}"
+  path  = "/"
 }
 
 #
@@ -488,7 +493,7 @@ resource "aws_instance" "mod_ec2_instance_no_secondary_ebs" {
   ebs_optimized          = "${var.enable_ebs_optimization}"
   tenancy                = "${var.tenancy}"
   monitoring             = "${var.detailed_monitoring}"
-  iam_instance_profile   = "${aws_iam_instance_profile.instance_role_instance_profile.name}"
+  iam_instance_profile   = "${element(coalescelist(aws_iam_instance_profile.instance_role_instance_profile.*.name, list(var.instance_profile_override_name)), 0)}"
   user_data_base64       = "${base64encode(data.template_file.user_data.rendered)}"
 
   # coalescelist and list("") were used here due to element not being able to handle empty lists, even if conditional will not allow portion to execute
@@ -528,7 +533,7 @@ resource "aws_instance" "mod_ec2_instance_with_secondary_ebs" {
   ebs_optimized          = "${var.enable_ebs_optimization}"
   tenancy                = "${var.tenancy}"
   monitoring             = "${var.detailed_monitoring}"
-  iam_instance_profile   = "${aws_iam_instance_profile.instance_role_instance_profile.name}"
+  iam_instance_profile   = "${element(coalescelist(aws_iam_instance_profile.instance_role_instance_profile.*.name, list(var.instance_profile_override_name)), 0)}"
   user_data_base64       = "${base64encode(data.template_file.user_data.rendered)}"
 
   # coalescelist and list("") were used here due to element not being able to handle empty lists, even if conditional will not allow portion to execute

--- a/variables.tf
+++ b/variables.tf
@@ -287,6 +287,18 @@ variable "custom_cw_agent_config_ssm_param" {
 # Roles and Policies
 #
 
+variable "instance_profile_override" {
+  description = "Optionally provide an instance profile. Any override profile should contain the permissions required for Rackspace support tooling to continue to function if required."
+  type        = "string"
+  default     = false
+}
+
+variable "instance_profile_override_name" {
+  description = "Provide an instance profile name. Any override profile should contain the permissions required for Rackspace support tooling to continue to function if required. To use this set `instance_profile_override` to `true`."
+  type        = "string"
+  default     = ""
+}
+
 variable "instance_role_managed_policy_arns" {
   description = "List of IAM policy ARNs for the InstanceRole IAM role. IAM ARNs can be found within the Policies section of the AWS IAM console. e.g. ['arn:aws:iam::aws:policy/AmazonEC2FullAccess', 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM', 'arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole']"
   type        = "list"


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/205

##### Summary of change(s):
Make use of the default role policy and the default SSM policy optional

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No

##### If input variables or output variables have changed or has been added, have you updated the README?
Yes

##### Do examples need to be updated based on changes?
No, though an advanced example could be added at a later date.

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.