### PR TITLE
Implement CloudWatch Alarm Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates one or more autorecovery instances.
 
 ```
 module "ar" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.0.2"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.0.10"
 
  ec2_os              = "amazon"
  subnets             = ["${module.vpc.private_subnets}"]
@@ -25,7 +25,6 @@ Full working references are available at [examples](examples)
 | additional\_ssm\_bootstrap\_list | A list of maps consisting of main step actions, to be appended to SSM associations. Please see usage.tf.example in this repo for examples. | list | `<list>` | no |
 | additional\_ssm\_bootstrap\_step\_count | Count of steps added for input 'additional_ssm_bootstrap_list'. This is required since 'additional_ssm_bootstrap_list' is a list of maps | string | `"0"` | no |
 | additional\_tags | Additional tags to be added to the EC2 instance Please see usage.tf.example in this repo for examples. | map | `<map>` | no |
-| alarm\_notification\_topic | SNS Topic ARN to notify if there are any alarms | string | `""` | no |
 | backup\_tag\_value | Value of the 'Backup' tag, used to assign te EBSSnapper configuration | string | `"False"` | no |
 | cloudwatch\_log\_retention | The number of days to retain Cloudwatch Logs for this instance. | string | `"30"` | no |
 | creation\_policy\_timeout | Time to wait for the number of signals for the creation policy. H/M/S Hours/Minutes/Seconds | string | `"20m"` | no |
@@ -56,6 +55,7 @@ Full working references are available at [examples](examples)
 | instance\_role\_managed\_policy\_arns | List of IAM policy ARNs for the InstanceRole IAM role. IAM ARNs can be found within the Policies section of the AWS IAM console. e.g. ['arn:aws:iam::aws:policy/AmazonEC2FullAccess', 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM', 'arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole'] | list | `<list>` | no |
 | instance\_type | EC2 Instance Type e.g. 't2.micro' | string | `"t2.micro"` | no |
 | key\_pair | Name of an existing EC2 KeyPair to enable SSH access to the instances. | string | `""` | no |
+| notification\_topic | SNS Topic ARN to notify if there are any alarms | string | `""` | no |
 | perform\_ssm\_inventory\_tag | Determines whether Instance is tracked via System Manager Inventory. | string | `"True"` | no |
 | primary\_ebs\_volume\_iops | Iops value required for use with io1 EBS volumes. This value should be 3 times the EBS volume size | string | `"0"` | no |
 | primary\_ebs\_volume\_size | EBS Volume Size in GB | string | `"60"` | no |

--- a/examples/custom_cw_agent_config.tf
+++ b/examples/custom_cw_agent_config.tf
@@ -18,7 +18,7 @@ module "vpc" {
 data "aws_region" "current_region" {}
 
 module "ec2_ar_with_codedeploy" {
-  source         = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.8"
+  source         = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.10"
   ec2_os         = "rhel6"
   instance_count = "1"
   subnets        = "${module.vpc.private_subnets}"

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -28,7 +28,7 @@ data "aws_ami" "amazon_centos_7" {
 }
 
 module "ec2_ar" {
-  source                            = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.8"
+  source                            = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.10"
   ec2_os                            = "centos7"
   instance_count                    = "3"
   subnets                           = "${module.vpc.public_subnets}"

--- a/examples/unmanaged.tf
+++ b/examples/unmanaged.tf
@@ -33,7 +33,7 @@ module "sns" {
 }
 
 module "unmanaged_ar" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.8"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.10"
 
   ec2_os                   = "centos7"
   instance_count           = "1"

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -62,7 +62,7 @@ module "ec2_ar_centos7_with_codedeploy" {
   cloudwatch_log_retention            = "30"
   ssm_association_refresh_rate        = "rate(1 day)"
   additional_ssm_bootstrap_step_count = "2"
-  alarm_notification_topic            = ""
+  notification_topic                  = ""
   disable_api_termination             = "False"
   t2_unlimited_mode                   = "standard"
   creation_policy_timeout             = "20m"
@@ -159,7 +159,7 @@ module "ec2_ar_centos7_no_codedeploy" {
   cloudwatch_log_retention            = "30"
   ssm_association_refresh_rate        = "rate(1 day)"
   additional_ssm_bootstrap_step_count = "2"
-  alarm_notification_topic            = ""
+  notification_topic                  = ""
   disable_api_termination             = "False"
   t2_unlimited_mode                   = "standard"
   creation_policy_timeout             = "20m"
@@ -250,7 +250,7 @@ module "ec2_ar_windows_with_codedeploy" {
   cloudwatch_log_retention            = "30"
   ssm_association_refresh_rate        = "rate(1 day)"
   additional_ssm_bootstrap_step_count = "2"
-  alarm_notification_topic            = ""
+  notification_topic                  = ""
   disable_api_termination             = "False"
   t2_unlimited_mode                   = "standard"
   creation_policy_timeout             = "20m"
@@ -337,7 +337,7 @@ module "ec2_ar_windows_no_codedeploy" {
   cloudwatch_log_retention            = "30"
   ssm_association_refresh_rate        = "rate(1 day)"
   additional_ssm_bootstrap_step_count = "2"
-  alarm_notification_topic            = ""
+  notification_topic                  = ""
   disable_api_termination             = "False"
   t2_unlimited_mode                   = "standard"
   creation_policy_timeout             = "20m"
@@ -393,29 +393,29 @@ module "sns" {
 module "unmanaged_ar" {
   source = "../../module"
 
-  ec2_os                   = "centos7"
-  instance_count           = "1"
-  subnets                  = ["${element(module.vpc.private_subnets, 0)}"]
-  security_group_list      = ["${module.vpc.default_sg}"]
-  image_id                 = "${data.aws_ami.amazon_centos_7.image_id}"
-  instance_type            = "t2.micro"
-  resource_name            = "my_unmanaged_instance-${random_string.res_name.result}"
-  alarm_notification_topic = "${module.sns.topic_arn}"
-  rackspace_managed        = false
+  ec2_os              = "centos7"
+  instance_count      = "1"
+  subnets             = ["${element(module.vpc.private_subnets, 0)}"]
+  security_group_list = ["${module.vpc.default_sg}"]
+  image_id            = "${data.aws_ami.amazon_centos_7.image_id}"
+  instance_type       = "t2.micro"
+  resource_name       = "my_unmanaged_instance-${random_string.res_name.result}"
+  notification_topic  = "${module.sns.topic_arn}"
+  rackspace_managed   = false
 }
 
 module "zero_count_ar" {
   source = "../../module"
 
-  ec2_os                   = "centos7"
-  instance_count           = "0"
-  subnets                  = []
-  security_group_list      = ["${module.vpc.default_sg}"]
-  image_id                 = "${data.aws_ami.amazon_centos_7.image_id}"
-  instance_type            = "t2.micro"
-  resource_name            = "my_nonexistent_instance-${random_string.res_name.result}"
-  alarm_notification_topic = "${module.sns.topic_arn}"
-  rackspace_managed        = false
+  ec2_os              = "centos7"
+  instance_count      = "0"
+  subnets             = []
+  security_group_list = ["${module.vpc.default_sg}"]
+  image_id            = "${data.aws_ami.amazon_centos_7.image_id}"
+  instance_type       = "t2.micro"
+  resource_name       = "my_nonexistent_instance-${random_string.res_name.result}"
+  notification_topic  = "${module.sns.topic_arn}"
+  rackspace_managed   = false
 }
 
 module "ec2_nfs" {

--- a/variables.tf
+++ b/variables.tf
@@ -235,7 +235,7 @@ variable "ssm_patching_group" {
 # CloudWatch and Logs
 #
 
-variable "alarm_notification_topic" {
+variable "notification_topic" {
   description = "SNS Topic ARN to notify if there are any alarms"
   type        = "string"
   default     = ""


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/191
##### Summary of change(s):
Update `status_check_failed_system_alarm_ticket`, `status_check_failed_instance_alarm_ticket`, and `cpu_alarm_high` CloudWatch alarms to use the CloudWatch Alarm module.
Removed unused random string resource
##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
Yes, change causes replacement of CloudWatch alarms.
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
Yes, readme updated
##### Do examples need to be updated based on changes?
No
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.