### PR TITLE
Add enable_recovery_alarms parameter to allow disabling recovery alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Full working references are available at [examples](examples)
 | eip\_allocation\_id\_count | A count of supplied eip allocation IDs in variable eip_allocation_id_list | string | `"0"` | no |
 | eip\_allocation\_id\_list | A list of Allocation IDs of the EIPs you want to associate with the instance(s). This is one per instance. e.g. if you specify 2 for instance_count then you must supply two allocation ids  here. | list | `<list>` | no |
 | enable\_ebs\_optimization | Use EBS Optimized? true or false | string | `"false"` | no |
+| enable\_recovery\_alarms | Boolean parameter controlling if auto-recovery alarms should be created.  Recovery actions are not supported on all instance types and AMIs, especially those with ephemeral storage.  This parameter should be set to false for those cases. | string | `"true"` | no |
 | encrypt\_secondary\_ebs\_volume | Encrypt EBS Volume? true or false | string | `"false"` | no |
 | environment | Application environment for which this network is being created. Preferred value are Development, Integration, PreProduction, Production, QA, Staging, or Test | string | `"Development"` | no |
 | final\_userdata\_commands | Commands to be given at the end of userdata for an instance. This should generally not include bootstrapping or ssm install. | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -399,7 +399,7 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_system_alarm_ticket"
 }
 
 resource "aws_cloudwatch_metric_alarm" "status_check_failed_instance_alarm_reboot" {
-  count               = "${var.instance_count}"
+  count               = "${var.enable_recovery_alarms ? var.instance_count : 0}"
   alarm_name          = "${join("-", list("StatusCheckFailedInstanceAlarmReboot", var.resource_name, format("%03d",count.index+1)))}"
   alarm_description   = "Status checks have failed, rebooting system."
   namespace           = "AWS/EC2"
@@ -419,7 +419,7 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_instance_alarm_reboo
 }
 
 resource "aws_cloudwatch_metric_alarm" "status_check_failed_system_alarm_recover" {
-  count               = "${var.instance_count}"
+  count               = "${var.enable_recovery_alarms ? var.instance_count : 0}"
   alarm_name          = "${join("-", list("StatusCheckFailedSystemAlarmRecover", var.resource_name, format("%03d",count.index+1)))}"
   alarm_description   = "Status checks have failed for system, recovering instance"
   namespace           = "AWS/EC2"

--- a/variables.tf
+++ b/variables.tf
@@ -271,6 +271,12 @@ variable "cw_cpu_high_threshold" {
   default     = "90"
 }
 
+variable "enable_recovery_alarms" {
+  description = "Boolean parameter controlling if auto-recovery alarms should be created.  Recovery actions are not supported on all instance types and AMIs, especially those with ephemeral storage.  This parameter should be set to false for those cases."
+  type        = "string"
+  default     = true
+}
+
 variable "provide_custom_cw_agent_config" {
   description = "Set to true if a custom cloudwatch agent configuration has been provided in variable custom_cw_agent_config_ssm_param."
   type        = "string"


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/206

##### Summary of change(s):
Adds a control variable to enable or disable the recovery alarms, allowing creation of instance types that do not support recovery actions.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No, default is to retain the alarms.  If control variable is changed, alarms would be destroyed.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No

##### If input variables or output variables have changed or has been added, have you updated the README?
Yes, readme updated.
##### Do examples need to be updated based on changes?
No
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.