### PR TITLE
Add a busy wait ssm document

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -302,6 +302,7 @@ data "template_file" "ssm_bootstrap_template" {
   template = "${file("${path.module}/text/ssm_bootstrap_template.json")}"
 
   vars {
+    region              = "${data.aws_region.current_region.name}"
     cw_agent_param      = "${var.provide_custom_cw_agent_config ? var.custom_cw_agent_config_ssm_param : local.cw_config_parameter_name}"
     managed_ssm_docs    = "${var.rackspace_managed ? data.template_file.ssm_managed_commands.rendered : ""}"
     codedeploy_doc      = "${local.ssm_codedeploy_include[local.codedeploy_install]}"

--- a/text/ssm_bootstrap_template.json
+++ b/text/ssm_bootstrap_template.json
@@ -6,6 +6,15 @@
     {
       "action": "aws:runDocument",
       "inputs": {
+      "documentPath": "arn:aws:ssm:${region}:507897595701:document/Rack-BusyWait",
+      "documentType": "SSMDocument"
+      },
+      "name": "BusyWait",
+      "timeoutSeconds": 300
+    },
+    {
+      "action": "aws:runDocument",
+      "inputs": {
         "documentPath": "AWS-ConfigureAWSPackage",
         "documentParameters": {
           "action": "Install",


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/218
##### Summary of change(s):
- Adds new SSM document  that is run first in the executiuon order.  As designed it will block until cloud-init  and systemd( where applicable), have completed their runs

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No.

##### If input variables or output variables have changed or has been added, have you updated the README?
No and No

##### Do examples need to be updated based on changes?
No

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.