### PR TITLE
Update default AMI filter to allow custom filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates one or more autorecovery instances.
 
 ```
 module "ar" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.0.10"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.0.14"
 
  ec2_os              = "amazon"
  subnets             = ["${module.vpc.private_subnets}"]

--- a/examples/custom_cw_agent_config.tf
+++ b/examples/custom_cw_agent_config.tf
@@ -18,7 +18,7 @@ module "vpc" {
 data "aws_region" "current_region" {}
 
 module "ec2_ar_with_codedeploy" {
-  source         = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.10"
+  source         = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.14"
   ec2_os         = "rhel6"
   instance_count = "1"
   subnets        = "${module.vpc.private_subnets}"

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -28,7 +28,7 @@ data "aws_ami" "amazon_centos_7" {
 }
 
 module "ec2_ar" {
-  source                            = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.10"
+  source                            = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.14"
   ec2_os                            = "centos7"
   instance_count                    = "3"
   subnets                           = "${module.vpc.public_subnets}"

--- a/examples/unmanaged.tf
+++ b/examples/unmanaged.tf
@@ -33,7 +33,7 @@ module "sns" {
 }
 
 module "unmanaged_ar" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.10"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.14"
 
   ec2_os                   = "centos7"
   instance_count           = "1"

--- a/main.tf
+++ b/main.tf
@@ -137,6 +137,7 @@ EOF
     windows2016   = "Windows_Server-2016-English-Full-Base*"
   }
 
+  # Any custom AMI filters for a given OS can be added in this mapping
   image_filter = {
     amazon        = []
     amazon2       = []
@@ -149,6 +150,7 @@ EOF
     windows2012R2 = []
     windows2016   = []
 
+    # Added to ensure only AMIS under the official CentOS 6 product code are retrieved
     centos6 = [
       {
         name   = "product-code"
@@ -156,6 +158,7 @@ EOF
       },
     ]
 
+    # Added to ensure only AMIS under the official CentOS 7 product code are retrieved
     centos7 = [
       {
         name   = "product-code"

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
  *
  *```
  *module "ar" {
- *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.0.10"
+ *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.0.14"
  *
  *  ec2_os              = "amazon"
  *  subnets             = ["${module.vpc.private_subnets}"]
@@ -137,6 +137,48 @@ EOF
     windows2016   = "Windows_Server-2016-English-Full-Base*"
   }
 
+  image_filter = {
+    amazon        = []
+    amazon2       = []
+    rhel6         = []
+    rhel7         = []
+    ubuntu14      = []
+    ubuntu16      = []
+    ubuntu18      = []
+    windows2008   = []
+    windows2012R2 = []
+    windows2016   = []
+
+    centos6 = [
+      {
+        name   = "product-code"
+        values = ["6x5jmcajty9edm3f211pqjfn2"]
+      },
+    ]
+
+    centos7 = [
+      {
+        name   = "product-code"
+        values = ["aw0evgkw8e5c1q413zgy5pjce"]
+      },
+    ]
+  }
+
+  standard_filters = [
+    {
+      name   = "virtualization-type"
+      values = ["hvm"]
+    },
+    {
+      name   = "root-device-type"
+      values = ["ebs"]
+    },
+    {
+      name   = "name"
+      values = ["${local.ami_name_mapping[var.ec2_os]}"]
+    },
+  ]
+
   cw_config_parameter_name = "CWAgent-${var.resource_name}"
 }
 
@@ -144,21 +186,7 @@ EOF
 data "aws_ami" "ar_ami" {
   most_recent = true
   owners      = ["${local.ami_owner_mapping[var.ec2_os]}"]
-
-  filter {
-    name   = "name"
-    values = ["${local.ami_name_mapping[var.ec2_os]}"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
+  filter      = "${concat(local.standard_filters, local.image_filter[var.ec2_os])}"
 }
 
 data "template_file" "user_data" {

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -18,17 +18,6 @@ module "vpc" {
 
 data "aws_region" "current_region" {}
 
-# Lookup the correct AMI based on the region specified
-data "aws_ami" "amazon_centos_7" {
-  most_recent = true
-  owners      = ["679593333241"]
-
-  filter {
-    name   = "name"
-    values = ["CentOS Linux 7 x86_64 HVM EBS*"]
-  }
-}
-
 resource "aws_eip" "test_eip_1" {
   vpc = true
 
@@ -129,7 +118,6 @@ module "ec2_ar_centos7_no_codedeploy" {
   instance_count               = "3"
   subnets                      = "${module.vpc.public_subnets}"
   security_group_list          = ["${module.vpc.default_sg}"]
-  image_id                     = "${data.aws_ami.amazon_centos_7.image_id}"
   key_pair                     = "CircleCI"
   instance_type                = "t2.micro"
   resource_name                = "ar_centos7_noncodedeploy-${random_string.res_name.result}"
@@ -212,22 +200,12 @@ EOF
   }
 }
 
-data "aws_ami" "amazon_windows_2016" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["Windows_Server-2016-English-Full-Base-*"]
-  }
-}
-
 module "ec2_ar_windows_with_codedeploy" {
   source                              = "../../module"
   ec2_os                              = "windows2016"
   instance_count                      = "3"
   subnets                             = "${module.vpc.public_subnets}"
   security_group_list                 = ["${module.vpc.default_sg}"]
-  image_id                            = "${data.aws_ami.amazon_windows_2016.image_id}"
   key_pair                            = "CircleCI"
   instance_type                       = "t2.micro"
   resource_name                       = "ar_windows_codedeploy-${random_string.res_name.result}"
@@ -308,7 +286,6 @@ module "ec2_ar_windows_no_codedeploy" {
     "${module.vpc.default_sg}",
   ]
 
-  image_id                     = "${data.aws_ami.amazon_windows_2016.image_id}"
   key_pair                     = "CircleCI"
   instance_type                = "t2.micro"
   resource_name                = "ar_windows_noncodedeploy-${random_string.res_name.result}"
@@ -397,7 +374,6 @@ module "unmanaged_ar" {
   instance_count      = "1"
   subnets             = ["${element(module.vpc.private_subnets, 0)}"]
   security_group_list = ["${module.vpc.default_sg}"]
-  image_id            = "${data.aws_ami.amazon_centos_7.image_id}"
   instance_type       = "t2.micro"
   resource_name       = "my_unmanaged_instance-${random_string.res_name.result}"
   notification_topic  = "${module.sns.topic_arn}"
@@ -411,7 +387,6 @@ module "zero_count_ar" {
   instance_count      = "0"
   subnets             = []
   security_group_list = ["${module.vpc.default_sg}"]
-  image_id            = "${data.aws_ami.amazon_centos_7.image_id}"
   instance_type       = "t2.micro"
   resource_name       = "my_nonexistent_instance-${random_string.res_name.result}"
   notification_topic  = "${module.sns.topic_arn}"


### PR DESCRIPTION
##### Corresponding Issue(s):
 - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section
[MPCSUPENG-297](https://jira.rax.io/browse/MPCSUPENG-297)
##### Summary of change(s):
Updates AMI Filters to allow setting additional custom filters per OS.  Adds initial filters to limit CentOS AMIs to expected product codes.

##### Reason for Change(s):

- Build errors for CentOS 7 due to AMI with expected name but unexpected product code.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No

##### If input variables or output variables have changed or has been added, have you updated the README?
Yes, Readme updated

##### Do examples need to be updated based on changes?
Yes examples updated

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
