### PR TITLE
Remove userdata exit 0's when SSM is found because it blocks final cmds

### DIFF
--- a/text/rhel_centos_6_userdata.sh
+++ b/text/rhel_centos_6_userdata.sh
@@ -13,7 +13,6 @@ pip install --upgrade awscli pystache argparse
 ssm_running=$( ps -ef | grep [a]mazon-ssm-agent | wc -l )
 if [[ $ssm_running != "0" ]]; then
     echo -e "amazon-ssm-agent already running"
-    exit 0
 else
     if [[ -r "/tmp/ssm_agent_install" ]]; then : ;
     else mkdir -p /tmp/ssm_agent_install; fi

--- a/text/rhel_centos_7_userdata.sh
+++ b/text/rhel_centos_7_userdata.sh
@@ -13,7 +13,6 @@ pip install --upgrade awscli pystache argparse
 ssm_running=$( ps -ef | grep [a]mazon-ssm-agent | wc -l )
 if [[ $ssm_running != "0" ]]; then
     echo -e "amazon-ssm-agent already running"
-    exit 0
 else
     if [[ -r "/tmp/ssm_agent_install" ]]; then : ;
     else mkdir -p /tmp/ssm_agent_install; fi

--- a/text/ubuntu_userdata.sh
+++ b/text/ubuntu_userdata.sh
@@ -12,7 +12,6 @@ pip install awscli --upgrade
 ssm_running=$( ps -ef | grep [a]mazon-ssm-agent | wc -l )
 if [[ $ssm_running != "0" ]]; then
     echo -e "amazon-ssm-agent already running"
-    exit 0
 else
     if [[ -r "/tmp/ssm_agent_install" ]]; then : ;
     else mkdir -p /tmp/ssm_agent_install; fi


### PR DESCRIPTION
##### Corresponding Issue(s):
 <!--- PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section --->

None

##### Summary of change(s):

Remove `exit 0` when SSM is found in CentOS, RHEL7 and Ubuntu userdata text files

##### Reason for Change(s):

The exit stops the final userdata commands running if SSM happens to be found

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No

##### If input variables or output variables have changed or has been added, have you updated the README?

N/A

##### Do examples need to be updated based on changes?

No

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
