### PR TITLE
Ensure dpkg does not not prompt for input

### DIFF
--- a/text/ubuntu_userdata.sh
+++ b/text/ubuntu_userdata.sh
@@ -5,6 +5,7 @@ ${initial_commands}
 exec 1> >(logger -s -t $(basename $0)) 2>&1
 
 export LC_ALL=C.UTF-8
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get -y install python-setuptools python-pip


### PR DESCRIPTION
##### Corresponding Issue(s):
n/a

##### Summary of change(s):
Adding DEBIAN_FRONTEND to userdata

##### Reason for Change(s):
Some package installs may prompt  input.  Adding this change suppresses that.


##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
no
##### If input variables or output variables have changed or has been added, have you updated the README?
no
##### Do examples need to be updated based on changes?
no
