### PR TITLE
Fix logic for testing if var.ec2_os is windows*

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,28 @@ This module creates one or more autorecovery instances.
 
 ## Basic Usage
 
-```
+```HCL
 module "ar" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.0.17"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.0.20"
 
- ec2_os              = "amazon"
- subnets             = ["${module.vpc.private_subnets}"]
- image_id            = "${var.image_id}"
- resource_name       = "my_ar_instance"
- security_group_list = ["${module.sg.private_web_security_group_id}"]
+  ec2_os              = "amazon"
+  subnets             = ["${module.vpc.private_subnets}"]
+  image_id            = "${var.image_id}"
+  resource_name       = "my_ar_instance"
+  security_group_list = ["${module.sg.private_web_security_group_id}"]
 }
 ```
 
 Full working references are available at [examples](examples)
-Note: When using an existing EBS snapshot you can not use the encryption variable. The encryption must be set at the snapshot level.
+_**Note**: When using an existing EBS snapshot you can not use the encryption variable. The encryption must be set at the snapshot level._
 
 ## Other TF Modules Used
 Using [aws-terraform-cloudwatch_alarm](https://github.com/rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm) to create the following CloudWatch Alarms:
-	- status_check_failed_system_alarm_ticket
-	- status_check_failed_instance_alarm_reboot
-	- status_check_failed_system_alarm_recover
-	- status_check_failed_instance_alarm_ticket
-	- cpu_alarm_high
+- status_check_failed_system_alarm_ticket
+- status_check_failed_instance_alarm_reboot
+- status_check_failed_system_alarm_recover
+- status_check_failed_instance_alarm_ticket
+- cpu_alarm_high
 
 ## Inputs
 
@@ -45,7 +45,7 @@ Using [aws-terraform-cloudwatch_alarm](https://github.com/rackspace-infrastructu
 | detailed\_monitoring | Enable Detailed Monitoring? true or false | string | `"true"` | no |
 | disable\_api\_termination | Specifies that an instance should not be able to be deleted via the API. true or false. This option must be toggled to false to allow Terraform to destroy the resource. | string | `"false"` | no |
 | ebs\_volume\_tags | (Optional) A mapping of tags to assign to the devices created by the instance at launch time. | map | `<map>` | no |
-| ec2\_os | Intended Operating System/Distribution of Instance. Valid inputs are ('amazon', 'rhel6', 'rhel7', 'centos6', 'centos7', 'ubuntu14', 'ubuntu16', 'windows2008', 'windows2012R2', 'windows2016') | string | n/a | yes |
+| ec2\_os | Intended Operating System/Distribution of Instance. Valid inputs are `amazon`, `amazon2`, `centos6`, `centos7`, `rhel6`, `rhel7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `windows2008`, `windows2012r2`, `windows2016`, `windows2019` | string | n/a | yes |
 | eip\_allocation\_id\_count | A count of supplied eip allocation IDs in variable eip_allocation_id_list | string | `"0"` | no |
 | eip\_allocation\_id\_list | A list of Allocation IDs of the EIPs you want to associate with the instance(s). This is one per instance. e.g. if you specify 2 for instance_count then you must supply two allocation ids  here. | list | `<list>` | no |
 | enable\_ebs\_optimization | Use EBS Optimized? true or false | string | `"false"` | no |

--- a/examples/custom_cw_agent_config.tf
+++ b/examples/custom_cw_agent_config.tf
@@ -11,14 +11,16 @@ resource "random_string" "res_name" {
 }
 
 module "vpc" {
-  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
+
   vpc_name = "EC2-AR-BaseNetwork-Test1"
 }
 
 data "aws_region" "current_region" {}
 
 module "ec2_ar_with_codedeploy" {
-  source         = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.19"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.20"
+
   ec2_os         = "rhel6"
   instance_count = "1"
   subnets        = "${module.vpc.private_subnets}"

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -4,7 +4,8 @@ provider "aws" {
 }
 
 module "vpc" {
-  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
+
   vpc_name = "EC2-AR-BaseNetwork-Test1"
 }
 
@@ -28,7 +29,8 @@ data "aws_ami" "amazon_centos_7" {
 }
 
 module "ec2_ar" {
-  source                       = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.19"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.20"
+
   ec2_os                       = "centos7"
   instance_count               = "3"
   subnets                      = "${module.vpc.public_subnets}"

--- a/examples/unmanaged.tf
+++ b/examples/unmanaged.tf
@@ -4,7 +4,8 @@ provider "aws" {
 }
 
 module "vpc" {
-  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.9"
+
   vpc_name = "EC2-AR-BaseNetwork-Test1"
 }
 
@@ -28,12 +29,13 @@ data "aws_ami" "amazon_centos_7" {
 }
 
 module "sns" {
-  source     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//?ref=v0.0.2"
+
   topic_name = "my-alarm-notification-topic"
 }
 
 module "unmanaged_ar" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.19"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.0.20"
 
   ec2_os              = "centos7"
   instance_count      = "1"

--- a/main.tf
+++ b/main.tf
@@ -1,75 +1,80 @@
 /**
  * # aws-terraform-ec2_autorecovery
  *
- *This module creates one or more autorecovery instances.
+ * This module creates one or more autorecovery instances.
  *
- *## Basic Usage
+ * ## Basic Usage
  *
- *```
- *module "ar" {
- *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.0.17"
+ * ```HCL
+ * module "ar" {
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.0.20"
  *
- *  ec2_os              = "amazon"
- *  subnets             = ["${module.vpc.private_subnets}"]
- *  image_id            = "${var.image_id}"
- *  resource_name       = "my_ar_instance"
- *  security_group_list = ["${module.sg.private_web_security_group_id}"]
- *}
- *```
+ *   ec2_os              = "amazon"
+ *   subnets             = ["${module.vpc.private_subnets}"]
+ *   image_id            = "${var.image_id}"
+ *   resource_name       = "my_ar_instance"
+ *   security_group_list = ["${module.sg.private_web_security_group_id}"]
+ * }
+ * ```
  *
  * Full working references are available at [examples](examples)
- * Note: When using an existing EBS snapshot you can not use the encryption variable. The encryption must be set at the snapshot level.
+ * _**Note**: When using an existing EBS snapshot you can not use the encryption variable. The encryption must be set at the snapshot level._
  *
  * ## Other TF Modules Used
  * Using [aws-terraform-cloudwatch_alarm](https://github.com/rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm) to create the following CloudWatch Alarms:
- * 	- status_check_failed_system_alarm_ticket
- * 	- status_check_failed_instance_alarm_reboot
- * 	- status_check_failed_system_alarm_recover
- * 	- status_check_failed_instance_alarm_ticket
- * 	- cpu_alarm_high
+ * - status_check_failed_system_alarm_ticket
+ * - status_check_failed_instance_alarm_reboot
+ * - status_check_failed_system_alarm_recover
+ * - status_check_failed_instance_alarm_ticket
+ * - cpu_alarm_high
  */
 
 locals {
+  ec2_os = "${lower(var.ec2_os)}"
+
+  ec2_os_windows_length_test = "${length(local.ec2_os) >= 7 ? 7 : length(local.ec2_os)}"
+  ec2_os_windows             = "${substr(local.ec2_os, 0, local.ec2_os_windows_length_test) == "windows" ? true : false}"
+
   user_data_map = {
     amazon        = "amazon_linux_userdata.sh"
     amazon2       = "amazon_linux_userdata.sh"
-    rhel6         = "rhel_centos_6_userdata.sh"
-    rhel7         = "rhel_centos_7_userdata.sh"
     centos6       = "rhel_centos_6_userdata.sh"
     centos7       = "rhel_centos_7_userdata.sh"
+    rhel6         = "rhel_centos_6_userdata.sh"
+    rhel7         = "rhel_centos_7_userdata.sh"
     ubuntu14      = "ubuntu_userdata.sh"
     ubuntu16      = "ubuntu_userdata.sh"
     ubuntu18      = "ubuntu_userdata.sh"
     windows2008   = "windows_userdata.ps1"
-    windows2012R2 = "windows_userdata.ps1"
+    windows2012r2 = "windows_userdata.ps1"
     windows2016   = "windows_userdata.ps1"
     windows2019   = "windows_userdata.ps1"
   }
 
   ebs_device_map = {
-    rhel6         = "/dev/sdf"
-    rhel7         = "/dev/sdf"
+    amazon        = "/dev/sdf"
+    amazon2       = "/dev/sdf"
     centos6       = "/dev/sdf"
     centos7       = "/dev/sdf"
-    windows2008   = "xvdf"
-    windows2012R2 = "xvdf"
-    windows2016   = "xvdf"
-    windows2019   = "xvdf"
+    rhel6         = "/dev/sdf"
+    rhel7         = "/dev/sdf"
     ubuntu14      = "/dev/sdf"
     ubuntu16      = "/dev/sdf"
     ubuntu18      = "/dev/sdf"
-    amazon        = "/dev/sdf"
-    amazon2       = "/dev/sdf"
+    windows2008   = "xvdf"
+    windows2012r2 = "xvdf"
+    windows2016   = "xvdf"
+    windows2019   = "xvdf"
   }
 
-  cwagent_config = "${var.ec2_os != "windows" ? "linux_cw_agent_param.json" : "windows_cw_agent_param.json"}"
+  cwagent_config = "${local.ec2_os_windows ? "windows_cw_agent_param.json" : "linux_cw_agent_param.json"}"
 
   tags = {
-    ServiceProvider = "Rackspace"
-    Environment     = "${var.environment}"
     Backup          = "${var.backup_tag_value}"
-    SSMInventory    = "${var.perform_ssm_inventory_tag}"
+    Environment     = "${var.environment}"
     "Patch Group"   = "${var.ssm_patching_group}"
+    ServiceProvider = "Rackspace"
+    SSMInventory    = "${var.perform_ssm_inventory_tag}"
   }
 
   ssm_codedeploy_include = {
@@ -89,7 +94,7 @@ EOF
 
   codedeploy_install = "${var.install_codedeploy_agent && var.rackspace_managed ? "enabled" : "disabled"}"
 
-  nfs_install = "${var.install_nfs && var.rackspace_managed && lookup(local.nfs_packages, var.ec2_os, "") != "" ? "enabled" : "disabled"}"
+  nfs_install = "${var.install_nfs && var.rackspace_managed && lookup(local.nfs_packages, local.ec2_os, "") != "" ? "enabled" : "disabled"}"
 
   nfs_packages = {
     amazon   = "nfs-utils"
@@ -108,7 +113,7 @@ EOF
         "documentType": "SSMDocument",
         "documentPath": "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-Install_Package",
         "documentParameters": {
-          "Packages": "${lookup(local.nfs_packages, var.ec2_os, "")}"
+          "Packages": "${lookup(local.nfs_packages, local.ec2_os, "")}"
         }
       },
       "name": "InstallNFS"
@@ -129,7 +134,7 @@ EOF
     ubuntu16      = "099720109477"
     ubuntu18      = "099720109477"
     windows2008   = "801119661308"
-    windows2012R2 = "801119661308"
+    windows2012r2 = "801119661308"
     windows2016   = "801119661308"
     windows2019   = "801119661308"
   }
@@ -145,7 +150,7 @@ EOF
     ubuntu16      = "*ubuntu-xenial-16.04-amd64-server*"
     ubuntu18      = "ubuntu/images/hvm-ssd/*ubuntu-bionic-18.04-amd64-server*"
     windows2008   = "Windows_Server-2008-R2_SP1-English-64Bit-Base*"
-    windows2012R2 = "Windows_Server-2012-R2_RTM-English-64Bit-Base*"
+    windows2012r2 = "Windows_Server-2012-R2_RTM-English-64Bit-Base*"
     windows2016   = "Windows_Server-2016-English-Full-Base*"
     windows2019   = "Windows_Server-2019-English-Full-Base*"
   }
@@ -160,7 +165,7 @@ EOF
     ubuntu16      = []
     ubuntu18      = []
     windows2008   = []
-    windows2012R2 = []
+    windows2012r2 = []
     windows2016   = []
     windows2019   = []
 
@@ -192,7 +197,7 @@ EOF
     },
     {
       name   = "name"
-      values = ["${local.ami_name_mapping[var.ec2_os]}"]
+      values = ["${local.ami_name_mapping[local.ec2_os]}"]
     },
   ]
 
@@ -202,12 +207,12 @@ EOF
 # Lookup the correct AMI based on the region specified
 data "aws_ami" "ar_ami" {
   most_recent = true
-  owners      = ["${local.ami_owner_mapping[var.ec2_os]}"]
-  filter      = "${concat(local.standard_filters, local.image_filter[var.ec2_os])}"
+  owners      = ["${local.ami_owner_mapping[local.ec2_os]}"]
+  filter      = "${concat(local.standard_filters, local.image_filter[local.ec2_os])}"
 }
 
 data "template_file" "user_data" {
-  template = "${file("${path.module}/text/${lookup(local.user_data_map, var.ec2_os)}")}"
+  template = "${file("${path.module}/text/${lookup(local.user_data_map, local.ec2_os)}")}"
 
   vars {
     initial_commands = "${var.initial_userdata_commands != "" ? "${var.initial_userdata_commands}" : "" }"
@@ -256,13 +261,13 @@ data "aws_iam_policy_document" "mod_ec2_instance_role_policies" {
     effect = "Allow"
 
     actions = [
-      "cloudwatch:PutMetricData",
       "cloudwatch:GetMetricStatistics",
       "cloudwatch:ListMetrics",
-      "logs:CreateLogStream",
+      "cloudwatch:PutMetricData",
       "ec2:DescribeTags",
-      "logs:DescribeLogStreams",
       "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
       "logs:PutLogEvents",
       "ssm:GetParameter",
     ]
@@ -278,48 +283,55 @@ data "aws_iam_policy_document" "mod_ec2_instance_role_policies" {
 }
 
 resource "aws_iam_policy" "create_instance_role_policy" {
-  count       = "${var.instance_profile_override ? 0 : 1}"
+  count = "${var.instance_profile_override ? 0 : 1}"
+
   name        = "InstanceRolePolicy-${var.resource_name}"
   description = "Rackspace Instance Role Policies for EC2"
   policy      = "${data.aws_iam_policy_document.mod_ec2_instance_role_policies.json}"
 }
 
 resource "aws_iam_role" "mod_ec2_instance_role" {
-  count              = "${var.instance_profile_override ? 0 : 1}"
+  count = "${var.instance_profile_override ? 0 : 1}"
+
   name               = "InstanceRole-${var.resource_name}"
   path               = "/"
   assume_role_policy = "${data.aws_iam_policy_document.mod_ec2_assume_role_policy_doc.json}"
 }
 
 resource "aws_iam_role_policy_attachment" "attach_ssm_policy" {
-  count      = "${var.instance_profile_override ? 0 : 1}"
+  count = "${var.instance_profile_override ? 0 : 1}"
+
   role       = "${aws_iam_role.mod_ec2_instance_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
 }
 
 resource "aws_iam_role_policy_attachment" "attach_codedeploy_policy" {
-  count      = "${var.install_codedeploy_agent && var.instance_profile_override != true ? 1 : 0}"
+  count = "${var.install_codedeploy_agent && var.instance_profile_override != true ? 1 : 0}"
+
   role       = "${aws_iam_role.mod_ec2_instance_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforAWSCodeDeploy"
 }
 
 resource "aws_iam_role_policy_attachment" "attach_instance_role_policy" {
-  count      = "${var.instance_profile_override ? 0 : 1}"
+  count = "${var.instance_profile_override ? 0 : 1}"
+
   role       = "${aws_iam_role.mod_ec2_instance_role.name}"
   policy_arn = "${aws_iam_policy.create_instance_role_policy.arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "attach_additonal_policies" {
-  count      = "${var.instance_profile_override ? 0 : var.instance_role_managed_policy_arn_count}"
+  count = "${var.instance_profile_override ? 0 : var.instance_role_managed_policy_arn_count}"
+
   role       = "${aws_iam_role.mod_ec2_instance_role.name}"
   policy_arn = "${element(var.instance_role_managed_policy_arns, count.index)}"
 }
 
 resource "aws_iam_instance_profile" "instance_role_instance_profile" {
   count = "${var.instance_profile_override ? 0 : 1}"
-  name  = "InstanceRoleInstanceProfile-${var.resource_name}"
-  role  = "${aws_iam_role.mod_ec2_instance_role.name}"
-  path  = "/"
+
+  name = "InstanceRoleInstanceProfile-${var.resource_name}"
+  role = "${aws_iam_role.mod_ec2_instance_role.name}"
+  path = "/"
 }
 
 #
@@ -335,8 +347,9 @@ data "template_file" "ssm_managed_commands" {
 }
 
 data "template_file" "additional_ssm_docs" {
+  count = "${var.additional_ssm_bootstrap_step_count}"
+
   template = "    $${additional_ssm_cmd_json},"
-  count    = "${var.additional_ssm_bootstrap_step_count}"
 
   vars {
     additional_ssm_cmd_json = "${trimspace(lookup(var.additional_ssm_bootstrap_list[count.index], "ssm_add_step"))}"
@@ -364,7 +377,8 @@ resource "aws_ssm_document" "ssm_bootstrap_doc" {
 }
 
 resource "aws_ssm_parameter" "cwagentparam" {
-  count       = "${var.provide_custom_cw_agent_config ? 0 : 1}"
+  count = "${var.provide_custom_cw_agent_config ? 0 : 1}"
+
   name        = "${local.cw_config_parameter_name}"
   description = "${var.resource_name} Cloudwatch Agent configuration"
   type        = "String"
@@ -372,7 +386,8 @@ resource "aws_ssm_parameter" "cwagentparam" {
 }
 
 resource "aws_ssm_association" "ssm_bootstrap_assoc" {
-  count               = "${var.instance_count == 0 ? 0 : 1}"
+  count = "${var.instance_count == 0 ? 0 : 1}"
+
   name                = "${aws_ssm_document.ssm_bootstrap_doc.name}"
   schedule_expression = "${var.ssm_association_refresh_rate}"
 
@@ -427,7 +442,8 @@ module "status_check_failed_system_alarm_ticket" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "status_check_failed_instance_alarm_reboot" {
-  count               = "${var.enable_recovery_alarms ? var.instance_count : 0}"
+  count = "${var.enable_recovery_alarms ? var.instance_count : 0}"
+
   alarm_description   = "Status checks have failed, rebooting system."
   alarm_name          = "${join("-", list("StatusCheckFailedInstanceAlarmReboot", var.resource_name, format("%03d",count.index+1)))}"
   comparison_operator = "GreaterThanThreshold"
@@ -444,7 +460,8 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_instance_alarm_reboo
 }
 
 resource "aws_cloudwatch_metric_alarm" "status_check_failed_system_alarm_recover" {
-  count               = "${var.enable_recovery_alarms ? var.instance_count : 0}"
+  count = "${var.enable_recovery_alarms ? var.instance_count : 0}"
+
   alarm_description   = "Status checks have failed for system, recovering instance"
   alarm_name          = "${join("-", list("StatusCheckFailedSystemAlarmRecover", var.resource_name, format("%03d",count.index+1)))}"
   comparison_operator = "GreaterThanThreshold"
@@ -506,8 +523,9 @@ module "cpu_alarm_high" {
 #
 
 resource "aws_instance" "mod_ec2_instance_no_secondary_ebs" {
+  count = "${var.secondary_ebs_volume_size != "" ? 0 : var.instance_count}"
+
   ami                    = "${var.image_id != "" ? var.image_id : data.aws_ami.ar_ami.image_id}"
-  count                  = "${var.secondary_ebs_volume_size != "" ? 0 : var.instance_count}"
   subnet_id              = "${element(var.subnets, count.index)}"
   vpc_security_group_ids = ["${var.security_group_list}"]
   instance_type          = "${var.instance_type}"
@@ -546,8 +564,9 @@ resource "aws_instance" "mod_ec2_instance_no_secondary_ebs" {
 }
 
 resource "aws_instance" "mod_ec2_instance_with_secondary_ebs" {
+  count = "${var.secondary_ebs_volume_size != "" ? var.instance_count : 0}"
+
   ami                    = "${var.image_id != "" ? var.image_id : data.aws_ami.ar_ami.image_id}"
-  count                  = "${var.secondary_ebs_volume_size != "" ? var.instance_count : 0}"
   subnet_id              = "${element(var.subnets, count.index)}"
   vpc_security_group_ids = ["${var.security_group_list}"]
   instance_type          = "${var.instance_type}"
@@ -575,7 +594,7 @@ resource "aws_instance" "mod_ec2_instance_with_secondary_ebs" {
   volume_tags = "${var.ebs_volume_tags}"
 
   ebs_block_device {
-    device_name = "${lookup(local.ebs_device_map, var.ec2_os)}"
+    device_name = "${lookup(local.ebs_device_map, local.ec2_os)}"
     volume_type = "${var.secondary_ebs_volume_type}"
     volume_size = "${var.secondary_ebs_volume_size}"
     iops        = "${var.secondary_ebs_volume_iops}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "ar_image_id" {
+  description = "Image ID used for EC2 provisioning"
+  value       = "${var.image_id != "" ? var.image_id : data.aws_ami.ar_ami.image_id}"
+}
+
 output "ar_instance_id_list" {
   description = "List of resulting Instance IDs"
 
@@ -8,9 +13,4 @@ output "ar_instance_ip_list" {
   description = "List of resulting Instance IP addresses"
 
   value = "${concat(aws_instance.mod_ec2_instance_with_secondary_ebs.*.private_ip, aws_instance.mod_ec2_instance_no_secondary_ebs.*.private_ip)}"
-}
-
-output "ar_image_id" {
-  description = "Image ID used for EC2 provisioning"
-  value       = "${var.image_id != "" ? var.image_id : data.aws_ami.ar_ami.image_id}"
 }

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -12,7 +12,8 @@ resource "random_string" "res_name" {
 }
 
 module "vpc" {
-  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=master"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=master"
+
   vpc_name = "EC2-AR-BaseNetwork-Test1-${random_string.res_name.result}"
 }
 
@@ -27,7 +28,8 @@ resource "aws_eip" "test_eip_1" {
 }
 
 module "ec2_ar_centos7_with_codedeploy" {
-  source                              = "../../module"
+  source = "../../module"
+
   ec2_os                              = "centos7"
   instance_count                      = "3"
   subnets                             = "${module.vpc.public_subnets}"
@@ -113,7 +115,8 @@ resource "aws_eip" "test_eip_2" {
 }
 
 module "ec2_ar_centos7_no_codedeploy" {
-  source                       = "../../module"
+  source = "../../module"
+
   ec2_os                       = "centos7"
   instance_count               = "3"
   subnets                      = "${module.vpc.public_subnets}"
@@ -201,7 +204,8 @@ EOF
 }
 
 module "ec2_ar_windows_with_codedeploy" {
-  source                              = "../../module"
+  source = "../../module"
+
   ec2_os                              = "windows2016"
   instance_count                      = "3"
   subnets                             = "${module.vpc.public_subnets}"
@@ -277,7 +281,8 @@ EOF
 }
 
 module "ec2_ar_windows_no_codedeploy" {
-  source         = "../../module"
+  source = "../../module"
+
   ec2_os         = "windows2016"
   instance_count = "3"
   subnets        = "${module.vpc.public_subnets}"
@@ -363,7 +368,8 @@ EOF
 }
 
 module "sns" {
-  source     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=master"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns?ref=master"
+
   topic_name = "my-alarm-notification-topic-${random_string.res_name.result}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "disable_api_termination" {
 }
 
 variable "ec2_os" {
-  description = "Intended Operating System/Distribution of Instance. Valid inputs are ('amazon', 'rhel6', 'rhel7', 'centos6', 'centos7', 'ubuntu14', 'ubuntu16', 'windows2008', 'windows2012R2', 'windows2016')"
+  description = "Intended Operating System/Distribution of Instance. Valid inputs are `amazon`, `amazon2`, `centos6`, `centos7`, `rhel6`, `rhel7`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `windows2008`, `windows2012r2`, `windows2016`, `windows2019`"
   type        = "string"
 }
 


### PR DESCRIPTION
##### Corresponding Issue(s):
<!--- PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section --->

N/A

##### Summary of change(s):

- general formatting to start aligning to standards
- old `windows` testing logic did not take into account changing to per Windows release years

##### Reason for Change(s):

<!--- If a bug, describe error scenario, including expected behavior and actual behavior. --->

<!--- If an enhancement, describe the use case and the perceived benefit(s). --->

Using a windows* flavour would not result in correct CW agent params.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

Should only update CW agent SSM parameter

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No

##### If input variables or output variables have changed or has been added, have you updated the README?

Done

##### Do examples need to be updated based on changes?

Done

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
