### PR TITLE
Optional installation of ScaleFT agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Using [aws-terraform-cloudwatch_alarm](https://github.com/rackspace-infrastructu
 | initial\_userdata\_commands | Commands to be given at the start of userdata for an instance. This should generally not include bootstrapping or ssm install. | string | `""` | no |
 | install\_codedeploy\_agent | Install codedeploy agent on instance(s)? true or false | string | `"false"` | no |
 | install\_nfs | Install NFS service on instance(s)? true or false | string | `"false"` | no |
+| install\_scaleft\_agent | Install scaleft agent on instance(s)? true or false | string | `"true"` | no |
 | instance\_count | Number of identical instances to deploy | string | `"1"` | no |
 | instance\_profile\_override | Optionally provide an instance profile. Any override profile should contain the permissions required for Rackspace support tooling to continue to function if required. | string | `"false"` | no |
 | instance\_profile\_override\_name | Provide an instance profile name. Any override profile should contain the permissions required for Rackspace support tooling to continue to function if required. To use this set `instance_profile_override` to `true`. | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,24 @@ EOF
     disabled = ""
   }
 
+  ssm_scaleft_include = {
+    enabled = <<EOF
+    {
+      "action": "aws:runDocument",
+      "inputs": {
+        "documentPath": "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-Install_ScaleFT",
+        "documentType": "SSMDocument"
+      },
+      "name": "SetupPassport",
+      "timeoutSeconds": 300
+    },
+EOF
+
+    disabled = ""
+  }
+
   codedeploy_install = "${var.install_codedeploy_agent && var.rackspace_managed ? "enabled" : "disabled"}"
+  scaleft_install    = "${var.install_scaleft_agent && var.rackspace_managed ? "enabled" : "disabled"}"
 
   nfs_install = "${var.install_nfs && var.rackspace_managed && lookup(local.nfs_packages, local.ec2_os, "") != "" ? "enabled" : "disabled"}"
 
@@ -409,6 +426,7 @@ data "template_file" "ssm_bootstrap_template" {
     cw_agent_param      = "${var.provide_custom_cw_agent_config ? var.custom_cw_agent_config_ssm_param : local.cw_config_parameter_name}"
     managed_ssm_docs    = "${var.rackspace_managed ? data.template_file.ssm_managed_commands.rendered : ""}"
     codedeploy_doc      = "${local.ssm_codedeploy_include[local.codedeploy_install]}"
+    scaleft_doc         = "${local.ssm_scaleft_include[local.scaleft_install]}"
     nfs_doc             = "${local.ssm_nfs_include[local.nfs_install]}"
     additional_ssm_docs = "${join("\n", data.template_file.additional_ssm_docs.*.rendered)}"
   }

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -203,6 +203,96 @@ EOF
   }
 }
 
+module "ec2_ar_centos7_no_scaleft" {
+  source = "../../module"
+
+  ec2_os                       = "centos7"
+  instance_count               = "3"
+  subnets                      = "${module.vpc.public_subnets}"
+  security_group_list          = ["${module.vpc.default_sg}"]
+  key_pair                     = "CircleCI"
+  instance_type                = "t2.micro"
+  resource_name                = "ar_centos7_nonscaleft-${random_string.res_name.result}"
+  install_codedeploy_agent     = false
+  install_scaleft_agent        = false
+  enable_ebs_optimization      = "False"
+  tenancy                      = "default"
+  backup_tag_value             = "False"
+  detailed_monitoring          = "True"
+  ssm_patching_group           = "Group1Patching"
+  primary_ebs_volume_size      = "60"
+  primary_ebs_volume_iops      = "0"
+  primary_ebs_volume_type      = "gp2"
+  secondary_ebs_volume_size    = "60"
+  secondary_ebs_volume_iops    = "0"
+  secondary_ebs_volume_type    = "gp2"
+  encrypt_secondary_ebs_volume = "False"
+
+  ebs_volume_tags = {
+    MyTag1 = "MyValue1"
+    MyTag2 = "MyValue2"
+    MyTag3 = "MyValue3"
+  }
+
+  environment                         = "Development"
+  instance_role_managed_policy_arns   = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole", "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access"]
+  perform_ssm_inventory_tag           = "True"
+  cloudwatch_log_retention            = "30"
+  ssm_association_refresh_rate        = "rate(1 day)"
+  additional_ssm_bootstrap_step_count = "2"
+  notification_topic                  = ""
+  disable_api_termination             = "False"
+  t2_unlimited_mode                   = "standard"
+  creation_policy_timeout             = "20m"
+  cw_cpu_high_operator                = "GreaterThanThreshold"
+  cw_cpu_high_threshold               = "90"
+  cw_cpu_high_evaluations             = "15"
+  cw_cpu_high_period                  = "60"
+  eip_allocation_id_count             = "1"
+  eip_allocation_id_list              = ["${aws_eip.test_eip_2.id}"]
+
+  additional_ssm_bootstrap_list = [
+    {
+      ssm_add_step = <<EOF
+      {
+        "action": "aws:runDocument",
+        "inputs": {
+          "documentPath": "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-Install_Package",
+          "documentParameters": {
+            "Packages": "bind bindutils"
+          },
+          "documentType": "SSMDocument"
+        },
+        "name": "InstallBindAndTools",
+        "timeoutSeconds": 300
+      }
+EOF
+    },
+    {
+      ssm_add_step = <<EOF
+      {
+        "action": "aws:runDocument",
+        "inputs": {
+          "documentPath": "AWS-RunShellScript",
+          "documentParameters": {
+            "commands": ["touch /tmp/myfile"]
+          },
+          "documentType": "SSMDocument"
+        },
+        "name": "CreateFile",
+        "timeoutSeconds": 300
+      }
+EOF
+    },
+  ]
+
+  additional_tags = {
+    MyTag1 = "MyValue1"
+    MyTag2 = "MyValue2"
+    MyTag3 = "MyValue3"
+  }
+}
+
 module "ec2_ar_windows_with_codedeploy" {
   source = "../../module"
 
@@ -295,6 +385,94 @@ module "ec2_ar_windows_no_codedeploy" {
   instance_type                = "t2.micro"
   resource_name                = "ar_windows_noncodedeploy-${random_string.res_name.result}"
   install_codedeploy_agent     = false
+  enable_ebs_optimization      = "False"
+  tenancy                      = "default"
+  backup_tag_value             = "False"
+  detailed_monitoring          = "True"
+  ssm_patching_group           = "Group1Patching"
+  primary_ebs_volume_size      = "60"
+  primary_ebs_volume_iops      = "0"
+  primary_ebs_volume_type      = "gp2"
+  secondary_ebs_volume_size    = "60"
+  secondary_ebs_volume_iops    = "0"
+  secondary_ebs_volume_type    = "gp2"
+  encrypt_secondary_ebs_volume = "False"
+  environment                  = "Development"
+
+  instance_role_managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
+    "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole",
+    "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access",
+  ]
+
+  perform_ssm_inventory_tag           = "True"
+  cloudwatch_log_retention            = "30"
+  ssm_association_refresh_rate        = "rate(1 day)"
+  additional_ssm_bootstrap_step_count = "2"
+  notification_topic                  = ""
+  disable_api_termination             = "False"
+  t2_unlimited_mode                   = "standard"
+  creation_policy_timeout             = "20m"
+  cw_cpu_high_operator                = "GreaterThanThreshold"
+  cw_cpu_high_threshold               = "90"
+  cw_cpu_high_evaluations             = "15"
+  cw_cpu_high_period                  = "60"
+
+  additional_ssm_bootstrap_list = [
+    {
+      ssm_add_step = <<EOF
+      {
+        "action": "aws:runDocument",
+        "inputs": {
+          "documentPath": "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-Install_Datadog",
+          "documentType": "SSMDocument"
+        },
+        "name": "InstallDataDog",
+        "timeoutSeconds": 300
+      }
+EOF
+    },
+    {
+      ssm_add_step = <<EOF
+      {
+        "action": "aws:runDocument",
+        "inputs": {
+          "documentPath": "AWS-RunPowerShellScript",
+          "documentParameters": {
+            "commands": ["echo $null >> C:\testfile"]
+          },
+          "documentType": "SSMDocument"
+        },
+        "name": "CreateFile",
+        "timeoutSeconds": 300
+      }
+EOF
+    },
+  ]
+
+  additional_tags = {
+    MyTag1 = "MyValue1"
+    MyTag2 = "MyValue2"
+    MyTag3 = "MyValue3"
+  }
+}
+
+module "ec2_ar_windows_no_scaleft" {
+  source = "../../module"
+
+  ec2_os         = "windows2016"
+  instance_count = "3"
+  subnets        = "${module.vpc.public_subnets}"
+
+  security_group_list = [
+    "${module.vpc.default_sg}",
+  ]
+
+  key_pair                     = "CircleCI"
+  instance_type                = "t2.micro"
+  resource_name                = "ar_windows_nonscaleft-${random_string.res_name.result}"
+  install_codedeploy_agent     = false
+  install_scaleft_agent        = false
   enable_ebs_optimization      = "False"
   tenancy                      = "default"
   backup_tag_value             = "False"

--- a/text/managed_ssm_steps.json
+++ b/text/managed_ssm_steps.json
@@ -10,15 +10,6 @@
     {
       "action": "aws:runDocument",
       "inputs": {
-      "documentPath": "arn:aws:ssm:${region}:507897595701:document/Rack-Install_ScaleFT",
-      "documentType": "SSMDocument"
-      },
-      "name": "SetupPassport",
-      "timeoutSeconds": 300
-    },
-    {
-      "action": "aws:runDocument",
-      "inputs": {
       "documentPath": "arn:aws:ssm:${region}:507897595701:document/Rack-Install_Package",
       "documentParameters": {
         "Packages": "sysstat ltrace strace iptraf tcpdump"

--- a/text/ssm_bootstrap_template.json
+++ b/text/ssm_bootstrap_template.json
@@ -40,7 +40,7 @@
       },
       "name": "ConfigureCWAgent",
       "timeoutSeconds": 300
-    },${managed_ssm_docs}${codedeploy_doc}${nfs_doc}${additional_ssm_docs}
+    },${managed_ssm_docs}${codedeploy_doc}${scaleft_doc}${nfs_doc}${additional_ssm_docs}
     {
       "action": "aws:runDocument",
       "inputs": {

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,12 @@ variable "install_codedeploy_agent" {
   default     = false
 }
 
+variable "install_scaleft_agent" {
+  description = "Install scaleft agent on instance(s)? true or false"
+  type        = "string"
+  default     = true
+}
+
 variable "install_nfs" {
   description = "Install NFS service on instance(s)? true or false"
   type        = "string"


### PR DESCRIPTION
* Add variable for making ScaleFT agent installation optional
* Remove ScaleFT from the main SSM bootstrap portion and make it an optional portion similar to the codedeploy segment
* Update readme with new variable description
* Update tests to assert a build with ScaleFT agent will run properly

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes

##### Testing

* Manually setup module on a test account and verified that the ScaleFT installation step was not included in the SSM command doc steps when disabled, and included when enabled
* Ran test terraform files with new module

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
