### PR TITLE
Remove Windows 2008 references since its EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ module "ar" {
   security_groups = ["${module.sg.private_web_security_group_id}"]
 }
 ```
+
 Full working references are available at [examples](examples)  
 \*Note\*\* When using an existing EBS snapshot you can not use the encryption variable. The encryption must be set at the snapshot level.\_
 
@@ -69,7 +70,7 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | detailed\_monitoring | Enable Detailed Monitoring? true or false | `bool` | `true` | no |
 | disable\_api\_termination | Specifies that an instance should not be able to be deleted via the API. true or false. This option must be toggled to false to allow Terraform to destroy the resource. | `bool` | `false` | no |
 | ebs\_volume\_tags | (Optional) A mapping of tags to assign to the devices created by the instance at launch time. | `map(string)` | `{}` | no |
-| ec2\_os | Intended Operating System/Distribution of Instance. Valid inputs are `amazon`, `amazon2`, `centos6`, `centos7`, `rhel6`, `rhel7`, `rhel8`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `windows2008`, `windows2012r2`, `windows2016`, `windows2019` | `string` | n/a | yes |
+| ec2\_os | Intended Operating System/Distribution of Instance. Valid inputs are `amazon`, `amazon2`, `centos6`, `centos7`, `rhel6`, `rhel7`, `rhel8`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `windows2012r2`, `windows2016`, `windows2019` | `string` | n/a | yes |
 | eip\_allocation\_id\_count | A count of supplied eip allocation IDs in variable eip\_allocation\_id\_list | `number` | `0` | no |
 | eip\_allocation\_id\_list | A list of Allocation IDs of the EIPs you want to associate with the instance(s). This is one per instance. e.g. if you specify 2 for instance\_count then you must supply two allocation ids  here. | `list(string)` | `[]` | no |
 | enable\_ebs\_optimization | Use EBS Optimized? true or false | `bool` | `false` | no |
@@ -118,3 +119,4 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | ar\_image\_id | Image ID used for EC2 provisioning |
 | ar\_instance\_id\_list | List of resulting Instance IDs |
 | ar\_instance\_ip\_list | List of resulting Instance IP addresses |
+

--- a/main.tf
+++ b/main.tf
@@ -210,7 +210,6 @@ locals {
     ubuntu14      = "ubuntu_userdata.sh"
     ubuntu16      = "ubuntu_userdata.sh"
     ubuntu18      = "ubuntu_userdata.sh"
-    windows2008   = "windows_userdata.ps1"
     windows2012r2 = "windows_userdata.ps1"
     windows2016   = "windows_userdata.ps1"
     windows2019   = "windows_userdata.ps1"
@@ -227,7 +226,6 @@ locals {
     ubuntu14      = "/dev/sdf"
     ubuntu16      = "/dev/sdf"
     ubuntu18      = "/dev/sdf"
-    windows2008   = "xvdf"
     windows2012r2 = "xvdf"
     windows2016   = "xvdf"
     windows2019   = "xvdf"
@@ -291,7 +289,6 @@ EOF
     ubuntu14      = "099720109477"
     ubuntu16      = "099720109477"
     ubuntu18      = "099720109477"
-    windows2008   = "801119661308"
     windows2012r2 = "801119661308"
     windows2016   = "801119661308"
     windows2019   = "801119661308"
@@ -308,7 +305,6 @@ EOF
     ubuntu14      = "*ubuntu-trusty-14.04-amd64-server*"
     ubuntu16      = "*ubuntu-xenial-16.04-amd64-server*"
     ubuntu18      = "ubuntu/images/hvm-ssd/*ubuntu-bionic-18.04-amd64-server*"
-    windows2008   = "Windows_Server-2008-R2_SP1-English-64Bit-Base*"
     windows2012r2 = "Windows_Server-2012-R2_RTM-English-64Bit-Base*"
     windows2016   = "Windows_Server-2016-English-Full-Base*"
     windows2019   = "Windows_Server-2019-English-Full-Base*"
@@ -324,7 +320,6 @@ EOF
     ubuntu14      = []
     ubuntu16      = []
     ubuntu18      = []
-    windows2008   = []
     windows2012r2 = []
     windows2016   = []
     windows2019   = []

--- a/variables.tf
+++ b/variables.tf
@@ -83,7 +83,7 @@ variable "encrypt_secondary_ebs_volume" {
 }
 
 variable "ec2_os" {
-  description = "Intended Operating System/Distribution of Instance. Valid inputs are `amazon`, `amazon2`, `centos6`, `centos7`, `rhel6`, `rhel7`, `rhel8`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `windows2008`, `windows2012r2`, `windows2016`, `windows2019`"
+  description = "Intended Operating System/Distribution of Instance. Valid inputs are `amazon`, `amazon2`, `centos6`, `centos7`, `rhel6`, `rhel7`, `rhel8`, `ubuntu14`, `ubuntu16`, `ubuntu18`, `windows2012r2`, `windows2016`, `windows2019`"
   type        = string
 }
 


### PR DESCRIPTION
##### Corresponding Issue(s):
https://jira.rax.io/browse/MPCSUPENG-917

##### Summary of change(s):
- Remove all Windows 2008 references. 
##### Reason for Change(s):

maintenance to keep pace with supported  OSes.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No. If you are using Windows 2008 then you  should not upgrade to this version of the module.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No.
##### If input variables or output variables have changed or has been added, have you updated the README?

Yes.

##### Do examples need to be updated based on changes?
No.
