### PR TITLE
adding r53 internal records support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This module creates one or more autorecovery instances.
 
 ```HCL
 module "ar" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.12.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.12.3"
 
   ec2_os              = "amazon"
-  subnets             = ["${module.vpc.private_subnets}"]
-  image_id            = "${var.image_id}"
+  subnets             = module.vpc.private_subnets
+  image_id            = var.image_id
   name                = "my_ar_instance"
-  security_groups = ["${module.sg.private_web_security_group_id}"]
+  security_groups = [module.sg.private_web_security_group_id]
 }
 ```  
 Full working references are available at [examples](examples)
@@ -60,6 +60,7 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | additional\_ssm\_bootstrap\_list | A list of maps consisting of main step actions, to be appended to SSM associations. Please see usage.tf.example in this repo for examples.<br><br>(DEPRECATED) This variable will be removed in future releases in favor of the `ssm_bootstrap_list` variable. | `list(map(string))` | `[]` | no |
 | backup\_tag\_value | Value of the 'Backup' tag, used to assign te EBSSnapper configuration | `string` | `"False"` | no |
 | cloudwatch\_log\_retention | The number of days to retain Cloudwatch Logs for this instance. | `number` | `30` | no |
+| create\_internal\_route53 | Toggle for creation of internal Route 53 records for instannces. | `bool` | `false` | no |
 | creation\_policy\_timeout | Time to wait for the number of signals for the creation policy. H/M/S Hours/Minutes/Seconds | `string` | `"20m"` | no |
 | custom\_cw\_agent\_config\_ssm\_param | SSM Parameter Store name that contains a custom CloudWatch agent configuration that you would like to use as an alternative to the default provided. | `string` | `""` | no |
 | cw\_cpu\_high\_evaluations | The number of periods over which data is compared to the specified threshold. | `number` | `15` | no |
@@ -88,6 +89,8 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | instance\_role\_managed\_policy\_arn\_count | The number of policy ARNs provided/set in variable 'instance\_role\_managed\_policy\_arns' | `number` | `0` | no |
 | instance\_role\_managed\_policy\_arns | List of IAM policy ARNs for the InstanceRole IAM role. IAM ARNs can be found within the Policies section of the AWS IAM console. e.g. ['arn:aws:iam::aws:policy/AmazonEC2FullAccess', 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM', 'arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole'] | `list(string)` | `[]` | no |
 | instance\_type | EC2 Instance Type e.g. 't2.micro' | `string` | `"t2.micro"` | no |
+| internal\_zone\_id | The Route53 Internal Hosted Zone ID | `string` | `""` | no |
+| internal\_zone\_name | TLD for Internal Hosted Zone | `string` | `""` | no |
 | key\_pair | Name of an existing EC2 KeyPair to enable SSH access to the instances. | `string` | `""` | no |
 | name | Name to be used for the provisioned EC2 instance(s) and other resources provisioned in this module | `string` | n/a | yes |
 | notification\_topic | SNS Topic ARN to notify if there are any alarms | `string` | `""` | no |
@@ -118,4 +121,5 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | ar\_image\_id | Image ID used for EC2 provisioning |
 | ar\_instance\_id\_list | List of resulting Instance IDs |
 | ar\_instance\_ip\_list | List of resulting Instance IP addresses |
+| ar\_instance\_r53\_name\_list | List of resulting Route 53 internal records |
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates one or more autorecovery instances.
 
 ```HCL
 module "ar" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.12.3"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.12.4"
 
   ec2_os              = "amazon"
   subnets             = module.vpc.private_subnets

--- a/examples/custom_cw_agent_config.tf
+++ b/examples/custom_cw_agent_config.tf
@@ -21,7 +21,7 @@ data "aws_region" "current_region" {
 }
 
 module "ec2_ar_with_codedeploy" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.3"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.4"
 
   ec2_os         = "rhel6"
   instance_count = 1

--- a/examples/managed.tf
+++ b/examples/managed.tf
@@ -98,7 +98,7 @@ module "ec2_ar" {
   cw_cpu_high_threshold   = 90
   disable_api_termination = false
   eip_allocation_id_count = 3
-  eip_allocation_id_list  = [aws_eip.my_eips.*.id]
+  eip_allocation_id_list  = aws_eip.my_eips.*.id
   notification_topic      = ""
   private_ip_address      = ["172.18.0.5", "172.18.4.5", "172.18.0.6"]
   t2_unlimited_mode       = "standard"

--- a/examples/managed.tf
+++ b/examples/managed.tf
@@ -30,7 +30,7 @@ data "aws_ami" "amazon_centos_7" {
 }
 
 module "ec2_ar" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.3"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.4"
 
   backup_tag_value             = "False"
   detailed_monitoring          = true

--- a/examples/unmanaged.tf
+++ b/examples/unmanaged.tf
@@ -36,7 +36,7 @@ module "sns" {
 }
 
 module "unmanaged_ar" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.3"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.4"
 
   ec2_os              = "centos7"
   image_id            = data.aws_ami.amazon_centos_7.image_id

--- a/main.tf
+++ b/main.tf
@@ -7,13 +7,13 @@
  *
  * ```HCL
  * module "ar" {
- *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.12.1"
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.12.3"
  *
  *   ec2_os              = "amazon"
- *   subnets             = ["${module.vpc.private_subnets}"]
- *   image_id            = "${var.image_id}"
+ *   subnets             = module.vpc.private_subnets
+ *   image_id            = var.image_id
  *   name                = "my_ar_instance"
- *   security_groups = ["${module.sg.private_web_security_group_id}"]
+ *   security_groups = [module.sg.private_web_security_group_id]
  * }
  * ```
  * Full working references are available at [examples](examples)
@@ -454,6 +454,31 @@ data "aws_iam_policy_document" "mod_ec2_instance_role_policies" {
   }
 }
 
+
+data "null_data_source" "instance_ips" {
+  count = var.instance_count
+
+  inputs = {
+    private_ip = element(
+      coalescelist(
+        aws_instance.mod_ec2_instance_with_secondary_ebs.*.private_ip,
+        aws_instance.mod_ec2_instance_no_secondary_ebs.*.private_ip,
+      ),
+      count.index,
+    )
+  }
+}
+
+resource "aws_route53_record" "instance" {
+  count = var.create_internal_route53 ? var.instance_count : 0
+
+  name    = "${var.name}${var.instance_count > 1 ? format("-%03d.", count.index + 1) : "."}${var.internal_zone_name}"
+  records = ["${data.null_data_source.instance_ips[count.index].outputs["private_ip"]}"]
+  ttl     = "300"
+  type    = "A"
+  zone_id = var.internal_zone_id
+
+}
 resource "aws_iam_policy" "create_instance_role_policy" {
   count = var.instance_profile_override ? 0 : 1
 

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
  *
  * ```HCL
  * module "ar" {
- *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.12.3"
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.12.4"
  *
  *   ec2_os              = "amazon"
  *   subnets             = module.vpc.private_subnets
@@ -140,15 +140,6 @@ locals {
         documentType = "SSMDocument"
       },
       name           = "DiagnosticTools",
-      timeoutSeconds = 300
-    },
-    {
-      action = "aws:runDocument",
-      inputs = {
-        documentPath = "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-SetMotd",
-        documentType = "SSMDocument"
-      },
-      name           = "SetMotd",
       timeoutSeconds = 300
     },
   ]

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,3 +21,7 @@ output "ar_instance_ip_list" {
   )
 }
 
+output "ar_instance_r53_name_list" {
+  description = "List of resulting Route 53 internal records"
+  value       = var.create_internal_route53 ? aws_route53_record.instance.*.fqdn : []
+}

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -12,13 +12,23 @@ resource "random_string" "res_name" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=master"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.0"
 
   name = "${random_string.res_name.result}-EC2-AR-BaseNetwork-Test1"
 }
 
 data "aws_region" "current_region" {
 }
+
+
+module "internal_zone" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//?ref=v0.12.0"
+
+  environment = "Test"
+  name        = "circleCITesting.local"
+  vpc_id      = module.vpc.vpc_id
+}
+
 
 resource "aws_eip" "test_eip_1" {
   vpc = true
@@ -32,29 +42,29 @@ module "ec2_ar_centos7_with_codedeploy" {
   source = "../../module"
 
   backup_tag_value                  = "False"
-  cloudwatch_log_retention          = "30"
+  cloudwatch_log_retention          = 30
   creation_policy_timeout           = "20m"
-  cw_cpu_high_evaluations           = "15"
+  cw_cpu_high_evaluations           = 15
   cw_cpu_high_operator              = "GreaterThanThreshold"
-  cw_cpu_high_period                = "60"
-  cw_cpu_high_threshold             = "90"
+  cw_cpu_high_period                = 60
+  cw_cpu_high_threshold             = 90
   detailed_monitoring               = true
   disable_api_termination           = false
-  eip_allocation_id_count           = "1"
+  eip_allocation_id_count           = 1
   eip_allocation_id_list            = [aws_eip.test_eip_1.id]
   enable_ebs_optimization           = false
   encrypt_secondary_ebs_volume      = false
   environment                       = "Development"
   install_codedeploy_agent          = true
-  instance_count                    = "3"
+  instance_count                    = 3
   instance_role_managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole", "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access"]
   instance_type                     = "t2.micro"
   key_pair                          = "CircleCI"
   name                              = "${random_string.res_name.result}-ar_centos7_codedeploy"
   notification_topic                = ""
   perform_ssm_inventory_tag         = true
-  primary_ebs_volume_iops           = "0"
-  primary_ebs_volume_size           = "60"
+  primary_ebs_volume_iops           = 0
+  primary_ebs_volume_size           = 60
   primary_ebs_volume_type           = "gp2"
   security_groups                   = [module.vpc.default_sg]
   ssm_association_refresh_rate      = "rate(1 day)"
@@ -83,7 +93,7 @@ module "ec2_ar_centos7_no_codedeploy" {
   source = "../../module"
 
   ec2_os                       = "centos7"
-  instance_count               = "3"
+  instance_count               = 1
   subnets                      = module.vpc.public_subnets
   security_groups              = [module.vpc.default_sg]
   key_pair                     = "CircleCI"
@@ -95,11 +105,11 @@ module "ec2_ar_centos7_no_codedeploy" {
   backup_tag_value             = "False"
   detailed_monitoring          = true
   ssm_patching_group           = "Group1Patching"
-  primary_ebs_volume_size      = "60"
-  primary_ebs_volume_iops      = "0"
+  primary_ebs_volume_size      = 60
+  primary_ebs_volume_iops      = 0
   primary_ebs_volume_type      = "gp2"
-  secondary_ebs_volume_size    = "60"
-  secondary_ebs_volume_iops    = "0"
+  secondary_ebs_volume_size    = 60
+  secondary_ebs_volume_iops    = 0
   secondary_ebs_volume_type    = "gp2"
   encrypt_secondary_ebs_volume = false
 
@@ -108,17 +118,17 @@ module "ec2_ar_centos7_no_codedeploy" {
   environment                       = "Development"
   instance_role_managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole", "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access"]
   perform_ssm_inventory_tag         = true
-  cloudwatch_log_retention          = "30"
+  cloudwatch_log_retention          = 30
   ssm_association_refresh_rate      = "rate(1 day)"
   notification_topic                = ""
   disable_api_termination           = false
   t2_unlimited_mode                 = "standard"
   creation_policy_timeout           = "20m"
   cw_cpu_high_operator              = "GreaterThanThreshold"
-  cw_cpu_high_threshold             = "90"
-  cw_cpu_high_evaluations           = "15"
-  cw_cpu_high_period                = "60"
-  eip_allocation_id_count           = "1"
+  cw_cpu_high_threshold             = 90
+  cw_cpu_high_evaluations           = 15
+  cw_cpu_high_period                = 60
+  eip_allocation_id_count           = 1
   eip_allocation_id_list            = [aws_eip.test_eip_2.id]
 
   ebs_volume_tags = {
@@ -138,8 +148,8 @@ module "ec2_ar_centos7_no_scaleft" {
   source = "../../module"
 
   ec2_os                       = "centos7"
-  instance_count               = "3"
-  subnets                      = module.vpc.public_subnets
+  instance_count               = 1
+  subnets                      = module.vpc.private_subnets
   security_groups              = [module.vpc.default_sg]
   key_pair                     = "CircleCI"
   instance_type                = "t2.micro"
@@ -151,11 +161,11 @@ module "ec2_ar_centos7_no_scaleft" {
   backup_tag_value             = "False"
   detailed_monitoring          = true
   ssm_patching_group           = "Group1Patching"
-  primary_ebs_volume_size      = "60"
-  primary_ebs_volume_iops      = "0"
+  primary_ebs_volume_size      = 60
+  primary_ebs_volume_iops      = 0
   primary_ebs_volume_type      = "gp2"
-  secondary_ebs_volume_size    = "60"
-  secondary_ebs_volume_iops    = "0"
+  secondary_ebs_volume_size    = 60
+  secondary_ebs_volume_iops    = 0
   secondary_ebs_volume_type    = "gp2"
   encrypt_secondary_ebs_volume = false
 
@@ -168,18 +178,17 @@ module "ec2_ar_centos7_no_scaleft" {
   environment                       = "Development"
   instance_role_managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole", "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access"]
   perform_ssm_inventory_tag         = true
-  cloudwatch_log_retention          = "30"
+  cloudwatch_log_retention          = 30
   ssm_association_refresh_rate      = "rate(1 day)"
   notification_topic                = ""
   disable_api_termination           = false
   t2_unlimited_mode                 = "standard"
   creation_policy_timeout           = "20m"
   cw_cpu_high_operator              = "GreaterThanThreshold"
-  cw_cpu_high_threshold             = "90"
-  cw_cpu_high_evaluations           = "15"
-  cw_cpu_high_period                = "60"
-  eip_allocation_id_count           = "1"
-  eip_allocation_id_list            = [aws_eip.test_eip_2.id]
+  cw_cpu_high_threshold             = 90
+  cw_cpu_high_evaluations           = 15
+  cw_cpu_high_period                = 60
+
 
   tags = {
     MyTag1 = "MyValue1"
@@ -192,8 +201,8 @@ module "ec2_ar_windows_with_codedeploy" {
   source = "../../module"
 
   ec2_os                            = "windows2016"
-  instance_count                    = "3"
-  subnets                           = module.vpc.public_subnets
+  instance_count                    = 1
+  subnets                           = module.vpc.private_subnets
   security_groups                   = [module.vpc.default_sg]
   key_pair                          = "CircleCI"
   instance_type                     = "t2.micro"
@@ -204,26 +213,26 @@ module "ec2_ar_windows_with_codedeploy" {
   backup_tag_value                  = "False"
   detailed_monitoring               = true
   ssm_patching_group                = "Group1Patching"
-  primary_ebs_volume_size           = "60"
-  primary_ebs_volume_iops           = "0"
+  primary_ebs_volume_size           = 60
+  primary_ebs_volume_iops           = 0
   primary_ebs_volume_type           = "gp2"
-  secondary_ebs_volume_size         = "60"
-  secondary_ebs_volume_iops         = "0"
+  secondary_ebs_volume_size         = 60
+  secondary_ebs_volume_iops         = 0
   secondary_ebs_volume_type         = "gp2"
   encrypt_secondary_ebs_volume      = false
   environment                       = "Development"
   instance_role_managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess", "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole", "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access"]
   perform_ssm_inventory_tag         = true
-  cloudwatch_log_retention          = "30"
+  cloudwatch_log_retention          = 30
   ssm_association_refresh_rate      = "rate(1 day)"
   notification_topic                = ""
   disable_api_termination           = false
   t2_unlimited_mode                 = "standard"
   creation_policy_timeout           = "20m"
   cw_cpu_high_operator              = "GreaterThanThreshold"
-  cw_cpu_high_threshold             = "90"
-  cw_cpu_high_evaluations           = "15"
-  cw_cpu_high_period                = "60"
+  cw_cpu_high_threshold             = 90
+  cw_cpu_high_evaluations           = 15
+  cw_cpu_high_period                = 60
 
   tags = {
     MyTag1 = "MyValue1"
@@ -250,11 +259,11 @@ module "ec2_ar_windows_no_codedeploy" {
   backup_tag_value             = "False"
   detailed_monitoring          = true
   ssm_patching_group           = "Group1Patching"
-  primary_ebs_volume_size      = "60"
-  primary_ebs_volume_iops      = "0"
+  primary_ebs_volume_size      = 60
+  primary_ebs_volume_iops      = 0
   primary_ebs_volume_type      = "gp2"
-  secondary_ebs_volume_size    = "60"
-  secondary_ebs_volume_iops    = "0"
+  secondary_ebs_volume_size    = 60
+  secondary_ebs_volume_iops    = 0
   secondary_ebs_volume_type    = "gp2"
   encrypt_secondary_ebs_volume = false
   environment                  = "Development"
@@ -266,16 +275,16 @@ module "ec2_ar_windows_no_codedeploy" {
   ]
 
   perform_ssm_inventory_tag    = true
-  cloudwatch_log_retention     = "30"
+  cloudwatch_log_retention     = 30
   ssm_association_refresh_rate = "rate(1 day)"
   notification_topic           = ""
   disable_api_termination      = false
   t2_unlimited_mode            = "standard"
   creation_policy_timeout      = "20m"
   cw_cpu_high_operator         = "GreaterThanThreshold"
-  cw_cpu_high_threshold        = "90"
-  cw_cpu_high_evaluations      = "15"
-  cw_cpu_high_period           = "60"
+  cw_cpu_high_threshold        = 90
+  cw_cpu_high_evaluations      = 15
+  cw_cpu_high_period           = 60
 
   tags = {
     MyTag1 = "MyValue1"
@@ -288,8 +297,8 @@ module "ec2_ar_windows_no_scaleft" {
   source = "../../module"
 
   ec2_os         = "windows2016"
-  instance_count = "3"
-  subnets        = module.vpc.public_subnets
+  instance_count = 1
+  subnets        = module.vpc.private_subnets
 
   security_groups = [module.vpc.default_sg]
 
@@ -303,11 +312,11 @@ module "ec2_ar_windows_no_scaleft" {
   backup_tag_value             = "False"
   detailed_monitoring          = true
   ssm_patching_group           = "Group1Patching"
-  primary_ebs_volume_size      = "60"
-  primary_ebs_volume_iops      = "0"
+  primary_ebs_volume_size      = 60
+  primary_ebs_volume_iops      = 0
   primary_ebs_volume_type      = "gp2"
-  secondary_ebs_volume_size    = "60"
-  secondary_ebs_volume_iops    = "0"
+  secondary_ebs_volume_size    = 60
+  secondary_ebs_volume_iops    = 0
   secondary_ebs_volume_type    = "gp2"
   encrypt_secondary_ebs_volume = false
   environment                  = "Development"
@@ -319,16 +328,16 @@ module "ec2_ar_windows_no_scaleft" {
   ]
 
   perform_ssm_inventory_tag    = true
-  cloudwatch_log_retention     = "30"
+  cloudwatch_log_retention     = 30
   ssm_association_refresh_rate = "rate(1 day)"
   notification_topic           = ""
   disable_api_termination      = false
   t2_unlimited_mode            = "standard"
   creation_policy_timeout      = "20m"
   cw_cpu_high_operator         = "GreaterThanThreshold"
-  cw_cpu_high_threshold        = "90"
-  cw_cpu_high_evaluations      = "15"
-  cw_cpu_high_period           = "60"
+  cw_cpu_high_threshold        = 90
+  cw_cpu_high_evaluations      = 15
+  cw_cpu_high_period           = 60
 
   tags = {
     MyTag1 = "MyValue1"
@@ -347,8 +356,8 @@ module "unmanaged_ar" {
   source = "../../module"
 
   ec2_os             = "centos7"
-  instance_count     = "1"
-  subnets            = [element(module.vpc.private_subnets, 0)]
+  instance_count     = 1
+  subnets            = module.vpc.private_subnets
   security_groups    = [module.vpc.default_sg]
   instance_type      = "t2.micro"
   name               = "${random_string.res_name.result}-test1-unmanaged_instance"
@@ -360,7 +369,7 @@ module "zero_count_ar" {
   source = "../../module"
 
   ec2_os             = "centos7"
-  instance_count     = "0"
+  instance_count     = 0
   subnets            = []
   security_groups    = [module.vpc.default_sg]
   instance_type      = "t2.micro"
@@ -372,17 +381,37 @@ module "zero_count_ar" {
 module "ec2_nfs" {
   source                    = "../../module"
   ec2_os                    = "amazon2"
-  instance_count            = "1"
+  instance_count            = 1
   subnets                   = module.vpc.private_subnets
   security_groups           = [module.vpc.default_sg]
   key_pair                  = "CircleCI"
   instance_type             = "t2.micro"
   name                      = "${random_string.res_name.result}-ar-nfs"
   install_nfs               = true
-  primary_ebs_volume_size   = "60"
-  primary_ebs_volume_iops   = "0"
+  primary_ebs_volume_size   = 60
+  primary_ebs_volume_iops   = 0
   primary_ebs_volume_type   = "gp2"
-  secondary_ebs_volume_size = "60"
-  secondary_ebs_volume_iops = "0"
+  secondary_ebs_volume_size = 60
+  secondary_ebs_volume_iops = 0
   secondary_ebs_volume_type = "gp2"
 }
+
+
+module "ar_r53" {
+  source = "../../module"
+
+  create_internal_route53 = true
+  ec2_os                  = "centos7"
+  instance_count          = 2
+  subnets                 = module.vpc.private_subnets
+  security_groups         = [module.vpc.default_sg]
+  instance_type           = "t2.micro"
+  internal_zone_id        = module.internal_zone.internal_hosted_zone_id
+  internal_zone_name      = module.internal_zone.internal_hosted_name
+  name                    = "${random_string.res_name.result}-test1-instance_r53"
+  notification_topic      = module.sns.topic_arn
+  rackspace_managed       = false
+
+}
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "cloudwatch_log_retention" {
   default     = 30
 }
 
+variable "create_internal_route53" {
+  description = "Toggle for creation of internal Route 53 records for instannces."
+  type        = bool
+  default     = false
+}
+
 variable "cw_cpu_high_evaluations" {
   description = "The number of periods over which data is compared to the specified threshold."
   type        = number
@@ -151,6 +157,18 @@ variable "instance_type" {
   description = "EC2 Instance Type e.g. 't2.micro'"
   type        = string
   default     = "t2.micro"
+}
+
+variable "internal_zone_name" {
+  description = "TLD for Internal Hosted Zone"
+  type        = string
+  default     = ""
+}
+
+variable "internal_zone_id" {
+  description = "The Route53 Internal Hosted Zone ID"
+  type        = string
+  default     = ""
 }
 
 variable "key_pair" {


### PR DESCRIPTION
##### Corresponding Issue(s):
- https://jira.rax.io/browse/MPCSUPENG-369
- https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/236
- https://jira.rax.io/browse/MPCSUPENG-1015
- https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/283
##### Summary of change(s):
- enhancement: add internal route53 record creation support
- bugfix.  Remove MOTD meant only for ASG instances

##### Reason for Change(s):
- feature parity
- standards request
- bugfix:  Remove MOTD meant only for ASG instances


##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
no
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
no
##### If input variables or output variables have changed or has been added, have you updated the README?
yes
##### Do examples need to be updated based on changes?
no
