### PR TITLE
Update inline IAM policy for EC2 instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates one or more autorecovery instances.
 
 ```HCL
 module "ar" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.12.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.12.6"
 
   ec2_os              = "amazon"
   subnets             = module.vpc.private_subnets

--- a/examples/custom_cw_agent_config.tf
+++ b/examples/custom_cw_agent_config.tf
@@ -12,16 +12,13 @@ resource "random_string" "res_name" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.1"
 
   name = "EC2-AR-BaseNetwork-Test1"
 }
 
-data "aws_region" "current_region" {
-}
-
 module "ec2_ar_with_codedeploy" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.6"
 
   ec2_os         = "rhel6"
   instance_count = 1

--- a/examples/managed.tf
+++ b/examples/managed.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.1"
 
   name = "EC2-AR-BaseNetwork-Test1"
 }
@@ -12,32 +12,14 @@ module "vpc" {
 data "aws_region" "current_region" {
 }
 
-# Lookup the correct AMI based on the region specified
-data "aws_ami" "amazon_centos_7" {
-  most_recent = true
-
-  owners = [
-    "679593333241",
-  ]
-
-  filter {
-    name = "name"
-
-    values = [
-      "CentOS Linux 7 x86_64 HVM EBS*",
-    ]
-  }
-}
-
 module "ec2_ar" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.6"
 
   backup_tag_value             = "False"
   detailed_monitoring          = true
   ec2_os                       = "centos7"
   enable_ebs_optimization      = false
   encrypt_secondary_ebs_volume = false
-  image_id                     = data.aws_ami.amazon_centos_7.image_id
   install_codedeploy_agent     = false
   instance_count               = 3
   instance_type                = "t2.micro"

--- a/examples/unmanaged.tf
+++ b/examples/unmanaged.tf
@@ -4,42 +4,21 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.1"
 
   name = "EC2-AR-BaseNetwork-Test1"
 }
 
-data "aws_region" "current_region" {
-}
-
-# Lookup the correct AMI based on the region specified
-data "aws_ami" "amazon_centos_7" {
-  most_recent = true
-
-  owners = [
-    "679593333241",
-  ]
-
-  filter {
-    name = "name"
-
-    values = [
-      "CentOS Linux 7 x86_64 HVM EBS*",
-    ]
-  }
-}
-
 module "sns" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//?ref=v0.12.1"
 
-  topic_name = "my-alarm-notification-topic"
+  name = "my-alarm-notification-topic"
 }
 
 module "unmanaged_ar" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.6"
 
   ec2_os              = "centos7"
-  image_id            = data.aws_ami.amazon_centos_7.image_id
   instance_count      = 1
   instance_type       = "t2.micro"
   notification_topic  = module.sns.topic_arn

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
  *
  * ```HCL
  * module "ar" {
- *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.12.4"
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery//?ref=v0.12.6"
  *
  *   ec2_os              = "amazon"
  *   subnets             = module.vpc.private_subnets
@@ -392,15 +392,20 @@ data "aws_iam_policy_document" "mod_ec2_assume_role_policy_doc" {
 data "aws_iam_policy_document" "mod_ec2_instance_role_policies" {
 
   statement {
+    effect    = "Allow"
+    resources = ["*"]
+
     actions = [
       "ssm:CreateAssociation",
       "ssm:DescribeInstanceInformation",
+      "ssm:GetParameter",
     ]
-    effect    = "Allow"
-    resources = ["*"]
   }
 
   statement {
+    effect    = "Allow"
+    resources = ["*"]
+
     actions = [
       "cloudwatch:GetMetricStatistics",
       "cloudwatch:ListMetrics",
@@ -410,38 +415,23 @@ data "aws_iam_policy_document" "mod_ec2_instance_role_policies" {
       "logs:CreateLogStream",
       "logs:DescribeLogStreams",
       "logs:PutLogEvents",
-      "ssm:GetParameter",
     ]
-    effect    = "Allow"
-    resources = ["*"]
   }
 
   statement {
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::rackspace-*/*"]
+
     actions = [
-      "s3:PutObject",
-      "s3:GetObject",
-      "s3:GetEncryptionConfiguration",
       "s3:AbortMultipartUpload",
-      "s3:ListMultipartUploadParts",
+      "s3:GetBucketLocation",
+      "s3:GetEncryptionConfiguration",
+      "s3:GetObject",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
     ]
-    effect    = "Allow"
-    resources = ["*"]
-  }
-
-  statement {
-    actions = [
-      "s3:GetBucketLocation",
-    ]
-    effect    = "Allow"
-    resources = ["*"]
-  }
-
-  statement {
-    actions   = ["ec2:DescribeTags"]
-    effect    = "Allow"
-    resources = ["*"]
   }
 }
 

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -17,10 +17,6 @@ module "vpc" {
   name = "${random_string.res_name.result}-EC2-AR-BaseNetwork-Test1"
 }
 
-data "aws_region" "current_region" {
-}
-
-
 module "internal_zone" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//?ref=v0.12.0"
 


### PR DESCRIPTION
##### Corresponding Issue(s):
 - [MPCSUPENG-962](https://jira.rax.io/browse/MPCSUPENG-962)

##### Summary of change(s):
Updates default inline IAM policy for EC2 instances to only allow access to buckets beginning with `rackspace-`. This will allow access to predetermined S3 files, and if additional S3 locations are required, a managed policy can be assigned to the instances IAM role via existing parameters.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
No variable or output changes.  Version pinning in readme and examples updated.
##### Do examples need to be updated based on changes?
Version pinning in readme and examples updated.
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.

