### PR TITLE
 Support CentOS 8

### DIFF
--- a/examples/custom_ami.tf
+++ b/examples/custom_ami.tf
@@ -74,11 +74,11 @@ module "ec2_ar" {
       inputs = {
         documentPath = "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-Install_Package",
         documentParameters = {
-          Packages = "bind bindutils"
+          Packages = "tmux"
         },
         documentType = "SSMDocument"
       },
-      name           = "InstallBindAndTools",
+      name           = "InstallTmux",
       timeoutSeconds = 300
     },
     {

--- a/examples/managed.tf
+++ b/examples/managed.tf
@@ -52,11 +52,11 @@ module "ec2_ar" {
       inputs = {
         documentPath = "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-Install_Package",
         documentParameters = {
-          Packages = "bind bindutils"
+          Packages = "tmux"
         },
         documentType = "SSMDocument"
       },
-      name           = "InstallBindAndTools",
+      name           = "InstallTmux",
       timeoutSeconds = 300
     },
     {

--- a/main.tf
+++ b/main.tf
@@ -194,6 +194,7 @@ locals {
     amazon2       = "amazon_linux_userdata.sh"
     centos6       = "rhel_centos_6_userdata.sh"
     centos7       = "rhel_centos_7_userdata.sh"
+    centos8       = "rhel_centos_8_userdata.sh"
     rhel6         = "rhel_centos_6_userdata.sh"
     rhel7         = "rhel_centos_7_userdata.sh"
     rhel8         = "rhel_centos_8_userdata.sh"
@@ -210,6 +211,7 @@ locals {
     amazon2       = "/dev/sdf"
     centos6       = "/dev/sdf"
     centos7       = "/dev/sdf"
+    centos8       = "/dev/sdf"
     rhel6         = "/dev/sdf"
     rhel7         = "/dev/sdf"
     rhel8         = "/dev/sdf"
@@ -271,7 +273,8 @@ EOF
     amazon        = "137112412989"
     amazon2       = "137112412989"
     centos6       = "679593333241"
-    centos7       = "679593333241"
+    centos7       = "125523088429"
+    centos8       = "125523088429"
     rhel6         = "309956199498"
     rhel7         = "309956199498"
     rhel8         = "309956199498"
@@ -287,7 +290,8 @@ EOF
     amazon        = "amzn-ami-hvm-2018.03.0.*gp2"
     amazon2       = "amzn2-ami-hvm-2.0.*-ebs"
     centos6       = "CentOS Linux 6 x86_64 HVM EBS*"
-    centos7       = "CentOS Linux 7 x86_64 HVM EBS*"
+    centos7       = "CentOS 7.* x86_64*"
+    centos8       = "CentOS 8.* x86_64*"
     rhel6         = "RHEL-6.*_HVM_GA-*x86_64*"
     rhel7         = "RHEL-7.*_HVM_GA-*x86_64*"
     rhel8         = "RHEL-8.*_HVM-*x86_64*"
@@ -306,6 +310,8 @@ EOF
     rhel6         = []
     rhel7         = []
     rhel8         = []
+    centos7       = []
+    centos8       = []
     ubuntu14      = []
     ubuntu16      = []
     ubuntu18      = []
@@ -317,13 +323,6 @@ EOF
       {
         name   = "product-code"
         values = ["6x5jmcajty9edm3f211pqjfn2"]
-      },
-    ]
-    # Added to ensure only AMIS under the official CentOS 7 product code are retrieved
-    centos7 = [
-      {
-        name   = "product-code"
-        values = ["aw0evgkw8e5c1q413zgy5pjce"]
       },
     ]
   }

--- a/text/rhel_centos_8_userdata.sh
+++ b/text/rhel_centos_8_userdata.sh
@@ -19,10 +19,7 @@ if [[ $ssm_running != "0" ]]; then
     echo -e "amazon-ssm-agent already running"
     exit 0
 else
-    if [[ -r "/tmp/ssm_agent_install" ]]; then : ;
-    else mkdir -p /tmp/ssm_agent_install; fi
-    curl https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm -o /tmp/ssm_agent_install/amazon-ssm-agent.rpm
-    rpm -Uvh /tmp/ssm_agent_install/amazon-ssm-agent.rpm
+    dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
     ssm_running=$( ps -ef | grep [a]mazon-ssm-agent | wc -l )
     systemctl=$( command -v systemctl | wc -l )
     if [[ $systemctl != "0" ]]; then


### PR DESCRIPTION
* Update all mappings to add it
* Update userdata to utilize dnf ssm agent installation
* Update CentOS 7/8 to use new official AMI account
* Remove product code check for CentOS7 since it's no longer coming from marketplace
* Update example to use tmux instead of bind and bind utils as the later has inconsistent naming across OS families and versions

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
