### PR TITLE
Memory collection metric set back to default.

### DIFF
--- a/text/linux_cw_agent_param.json
+++ b/text/linux_cw_agent_param.json
@@ -9,17 +9,10 @@
       ["AutoScalingGroupName"],
       ["InstanceId", "device"]
     ],
-    "namespace": "System/Linux",
     "metrics_collected": {
       "mem": {
         "metrics_collection_interval": 60,
-        "measurement": [
-          {
-            "rename": "MemoryUtilization",
-            "name": "mem_used_percent",
-            "unit": "Percent"
-          }
-        ]
+        "measurement": ["used_percent"]
       },
       "disk": {
         "ignore_file_system_types": [


### PR DESCRIPTION
##### Corresponding Issue(s):

Internally sourced from RS support teams.

##### Summary of change(s):

- The renaming of this metric was a hold over from a product that is no longer used at Rackspace, that for whatever reason had issues with the default AWS config. This is no longer the case and the metric has been set back.

##### Reason for Change(s):

Request from RS Support

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

##### If input variables or output variables have changed or has been added, have you updated the README?

##### Do examples need to be updated based on changes?

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
