### PR TITLE
Remove deprecated `template_file` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 |------|---------|
 | aws | >= 2.7.0 |
 | null | n/a |
-| template | n/a |
 
 ## Modules
 
@@ -89,7 +88,6 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | [aws_ssm_document](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/ssm_document) |
 | [aws_ssm_parameter](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/ssm_parameter) |
 | [null_data_source](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) |
-| [template_file](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) |
 
 ## Inputs
 

--- a/examples/custom_cw_agent_config.tf
+++ b/examples/custom_cw_agent_config.tf
@@ -1,5 +1,12 @@
+locals {
+  cwagent_vars = {
+    application_log_group_name = "custom_app_log_group_name"
+    system_log_group_name      = "custom_system_log_group_name"
+  }
+}
+
 provider "aws" {
-  version = "~> 2.7"
+  version = "~> 3.0"
   region  = "us-west-2"
 }
 
@@ -59,14 +66,5 @@ resource "aws_ssm_parameter" "custom_cwagentparam" {
   name        = "custom_cw_param-${random_string.res_name.result}"
   description = "Custom Cloudwatch Agent configuration"
   type        = "String"
-  value       = data.template_file.custom_cwagentparam.rendered
-}
-
-data "template_file" "custom_cwagentparam" {
-  template = file("./text/linux_cw_agent_param.json")
-
-  vars = {
-    application_log_group_name = "custom_app_log_group_name"
-    system_log_group_name      = "custom_system_log_group_name"
-  }
+  value       = templatefile("./text/linux_cw_agent_param.json", local.cwagent_vars)
 }


### PR DESCRIPTION
- `template_file` should no longer be used. `templatefile` function has replaced it.

##### Corresponding Issue(s):
 [MPCSUPENG-2862](https://rackspace.atlassian.net/browse/MPCSUPENG-3862)

##### Summary of change(s):
`data template_file` is deprecated. `templatefile` function has replaced.

##### Reason for Change(s):
Newer versions of TF do not have support for `template_file` especially if you are using a Mac with an M1 chip. The ARM version of TF will stop working if you are using versions higher than 0.15

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

It did not during tests.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

##### If input variables or output variables have changed or has been added, have you updated the README?

##### Do examples need to be updated based on changes?

Yes. Updated.

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.



Screenshots

![Screen Shot 2022-04-15 at 10 23 45 AM](https://user-images.githubusercontent.com/19778741/163604043-09b41a9b-5094-4e2d-8cc3-ef20b0a8cfc7.png)

![Screen Shot 2022-04-15 at 10 21 50 AM](https://user-images.githubusercontent.com/19778741/163604256-8fe5bc07-2af4-40c7-b182-5fc85755a2c8.png)