### PR TITLE
Fixed provider bug and centos fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,12 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 | Name | Version |
 |------|---------|
 | terraform | >= 1.0.0 |
-| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| aws | n/a |
 
 ## Modules
 
@@ -70,22 +69,22 @@ New variable `ssm_bootstrap_list` was added to allow setting the SSM association
 
 | Name |
 |------|
-| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/ami) |
-| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/caller_identity) |
-| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/cloudwatch_log_group) |
-| [aws_cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/cloudwatch_metric_alarm) |
-| [aws_eip_association](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/eip_association) |
-| [aws_iam_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/iam_instance_profile) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/iam_policy) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/iam_role) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/iam_role_policy_attachment) |
-| [aws_instance](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/instance) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/region) |
-| [aws_route53_record](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/route53_record) |
-| [aws_ssm_association](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/ssm_association) |
-| [aws_ssm_document](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/ssm_document) |
-| [aws_ssm_parameter](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/ssm_parameter) |
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) |
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) |
+| [aws_cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) |
+| [aws_eip_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) |
+| [aws_iam_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
+| [aws_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
+| [aws_route53_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) |
+| [aws_ssm_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_association) |
+| [aws_ssm_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_document) |
+| [aws_ssm_parameter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -58,10 +58,6 @@ terraform {
   required_version = ">= 1.0.0"
 }
 
-provider "aws" {
-  version = "~> 3.0"
-  region  = "us-west-2"
-}
 
 locals {
   ec2_os = lower(var.ec2_os)
@@ -317,7 +313,7 @@ EOF
   ami_name_mapping = {
     amazon2       = "amzn2-ami-hvm-2.0.*-ebs"
     amazon2022    = "al2022-ami-2022*-kernel-*-x86_64"
-    centos7       = "CentOS 7.* x86_64*"
+    centos7       = "CentOS Linux 7 x86_64 - *"
     rhel7         = "RHEL-7.*_HVM-*x86_64*"
     rhel8         = "RHEL-8.*_HVM-*x86_64*"
     ubuntu18      = "ubuntu/images/hvm-ssd/*ubuntu-bionic-18.04-amd64-server*"


### PR DESCRIPTION
- Remove provider block, according to [here](https://developer.hashicorp.com/terraform/language/meta-arguments/module-providers#default-behavior-inherit-default-providers) the module will get the region configuration from the parent modules that is calling it.
- Tested in local env
- Also changed the name of Centos 7, it was causing the pipeline to fail due that it was not able to find the image.